### PR TITLE
Fix gap between image and text

### DIFF
--- a/src/home/home.scss
+++ b/src/home/home.scss
@@ -175,15 +175,16 @@
       column-gap: 10%;
       font-family: Inter;
 
-      // .pic {
-      //   img {
-      //     width: 450px;
-      //     height: 450px;
-      //   }
-      // }
+      .pic {
+        img {
+            border-radius: 6px;
+          // width: 450px;
+          // height: 450px;
+        }
+      }
 
       .rightColumn {
-        width: 32em;
+        width: 100%;
         > .heading1 {
           -webkit-text-fill-color: $Secondary02;
         }
@@ -297,6 +298,7 @@
         .pic {
           grid-area: pic;
           img {
+            border-radius: 6px;
             width: 75%;
           }
         }
@@ -318,6 +320,7 @@
       &.fairLaunch {
         .pic {
           img {
+            border-radius: 6px;
             margin-left: -20px;
             margin-right: -20px;
             width: calc(100% + 40px);

--- a/src/home/home.scss
+++ b/src/home/home.scss
@@ -171,7 +171,7 @@
 
     &.fairLaunch {
       display: grid;
-      grid-template-columns: auto auto;
+      grid-template-columns: auto 1fr;
       column-gap: 10%;
       font-family: Inter;
 
@@ -183,7 +183,6 @@
       // }
 
       .rightColumn {
-        width: 100%;
         > .heading1 {
           -webkit-text-fill-color: $Secondary02;
         }

--- a/src/home/home.scss
+++ b/src/home/home.scss
@@ -320,7 +320,7 @@
       &.fairLaunch {
         .pic {
           img {
-            border-radius: 6px;
+            border-radius: 0;
             margin-left: -20px;
             margin-right: -20px;
             width: calc(100% + 40px);

--- a/src/home/home.scss
+++ b/src/home/home.scss
@@ -175,13 +175,12 @@
       column-gap: 10%;
       font-family: Inter;
 
-      .pic {
-        img {
-            border-radius: 6px;
-          // width: 450px;
-          // height: 450px;
-        }
-      }
+      // .pic {
+      //   img {
+      //     width: 450px;
+      //     height: 450px;
+      //   }
+      // }
 
       .rightColumn {
         width: 100%;
@@ -298,7 +297,6 @@
         .pic {
           grid-area: pic;
           img {
-            border-radius: 6px;
             width: 75%;
           }
         }
@@ -320,7 +318,6 @@
       &.fairLaunch {
         .pic {
           img {
-            border-radius: 0;
             margin-left: -20px;
             margin-right: -20px;
             width: calc(100% + 40px);


### PR DESCRIPTION
- Gave the text full width, to eliminate the white-space between text and image as suggested in this [issue](https://www.notion.so/curvelabs/Close-the-Gap-between-Fair-Launches-Image-Text-1ce5060974984fdfa98849c49df3eb4c)

- Though not explicitly requested in Figma, I think it makes sense to add a border-radius to the image to keep it consistent with the rest of the elements/design.