### PR TITLE
Seed registration modifications

### DIFF
--- a/src/newSeed/baseStage.scss
+++ b/src/newSeed/baseStage.scss
@@ -579,7 +579,6 @@
       }
       .labelContainer {
         width: unset;
-        margin-bottom: 5px;
       }
     }
     .labeledQuestion {

--- a/src/newSeed/baseStage.scss
+++ b/src/newSeed/baseStage.scss
@@ -582,6 +582,9 @@
         margin-bottom: 5px;
       }
     }
+    .labeledQuestion {
+      margin-bottom: 5px;
+    }
     > .heading.heading2 {
       font-size: 26px;
     }

--- a/src/newSeed/baseStage.scss
+++ b/src/newSeed/baseStage.scss
@@ -579,6 +579,7 @@
       }
       .labelContainer {
         width: unset;
+        margin-bottom: 5px;
       }
     }
     > .heading.heading2 {
@@ -586,7 +587,6 @@
     }
     label {
       line-height: 20px;
-      margin-bottom: 5px;
     }
     .summaryContainer {
       margin-bottom: 30px;

--- a/src/newSeed/baseStage.scss
+++ b/src/newSeed/baseStage.scss
@@ -476,7 +476,6 @@
     .infoContainer {
       & textarea {
         height: 7em;
-        padding: 12px;
       }
     }
   }

--- a/src/newSeed/baseStage.scss
+++ b/src/newSeed/baseStage.scss
@@ -476,6 +476,7 @@
     .infoContainer {
       & textarea {
         height: 7em;
+        padding: 12px;
       }
     }
   }

--- a/src/newSeed/stage5.html
+++ b/src/newSeed/stage5.html
@@ -21,6 +21,7 @@
           <textarea
             id="remarks"
             value.bind="seedConfig.contactDetails.remarks"
+            placeholder="(Optional)"
             maxlength="250"></textarea>
         </div>
         <div class="buttonContainer">

--- a/src/resources/elements/questionMark/questionMark.scss
+++ b/src/resources/elements/questionMark/questionMark.scss
@@ -10,8 +10,5 @@
     color: $BG01;
     font-size: 1em;
     display: inline-flex;
-    align-items: center;
-    height: 100%;
-    position: relative;
   }
 }

--- a/src/resources/elements/questionMark/questionMark.scss
+++ b/src/resources/elements/questionMark/questionMark.scss
@@ -13,6 +13,5 @@
     align-items: center;
     height: 100%;
     position: relative;
-    bottom: 1px;
   }
 }

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -58,7 +58,7 @@ html {
       border: 1px solid $Neutral02;
       color: $White;
       outline: none;
-      padding: 0 12px;
+      padding: 12px 12px;
 
       &::placeholder {
         color: $Neutral03;


### PR DESCRIPTION
- Aligned the question mark vertically to the center- [issue](https://www.notion.so/curvelabs/Seed-Reg-Stage-2-Question-Marks-should-be-centered-7b0a85fa682049a88e9f52135c9cfc77)
- Added `Optional` place holder to the text area in stage 5 - [issue](https://www.notion.so/curvelabs/Seed-Reg-make-placeholders-consistent-in-wording-wrt-optional-31472724fbfa43d68e5ce4a6c95a2bcb)
- Added 12px padding inside text areas also from the top and bottom to keep it visually persistent with the other input boxes: 

<img width="328" alt="Screenshot 2021-07-10 at 10 57 26" src="https://user-images.githubusercontent.com/2517870/125157865-a8867100-e16d-11eb-9ea4-e5d247b4f883.png"> <img width="313" alt="Screenshot 2021-07-10 at 10 59 26" src="https://user-images.githubusercontent.com/2517870/125157906-ec797600-e16d-11eb-972f-8f7f3cbab6e0.png">

