### PR TITLE
remove category color inherit from the wrong class

### DIFF
--- a/src/newSeed/baseStage.scss
+++ b/src/newSeed/baseStage.scss
@@ -265,7 +265,9 @@
           flex-flow: row nowrap;
           justify-content: space-between;
           align-items: center;
-          color: $Neutral02;
+          span {
+            color: $Neutral02;
+          }
         }
         .infoInput {
           margin-bottom: unset;


### PR DESCRIPTION
The gray color, which should apply the _characters counter_, was applied to the whole `category` label element. I've moved the declaration to the `span` element containing this counter.