### PR TITLE
fix token name width

### DIFF
--- a/src/newSeed/baseStage.scss
+++ b/src/newSeed/baseStage.scss
@@ -522,8 +522,8 @@
             column-gap: 10px;
             align-items: center;
             width: fit-content;
-            & div {
-              align-self: center;
+            & .etherscanlink {
+              margin-right: 10px;
             }
             & > img {
               @include tokenIcon;
@@ -536,7 +536,6 @@
             background-color: $Shade03;
           }
         }
-
         &:not(:first-child) {
           margin-top: 40px;
         }

--- a/src/newSeed/baseStage.scss
+++ b/src/newSeed/baseStage.scss
@@ -518,20 +518,16 @@
 
           .tokenInfo {
             display: grid;
-            grid-template-columns: 1fr 0.5fr 0.5fr;
+            grid-template-columns: repeat(3, auto);
+            column-gap: 10px;
+            align-items: center;
             width: fit-content;
             & div {
               align-self: center;
-              margin-right: 0;
             }
             & > img {
               @include tokenIcon;
               height: 19px;
-            }
-            &.projectLogo {
-              grid-template-columns: auto auto;
-              align-items: center;
-              column-gap: 10px;
             }
           }
           hr {

--- a/src/newSeed/stage6.html
+++ b/src/newSeed/stage6.html
@@ -89,7 +89,7 @@
           <div class="heading heading4">
             Project Logo
           </div>
-          <div class="tokenInfo projectLogo">
+          <div class="tokenInfo">
             <img class="logoImage"
               src.to-view="seedConfig.projectDetails.logo" />
             <div class="ellipses"><a href="${seedConfig.projectDetails.logo}" target="_blank" rel="noopener noreferrer">${seedConfig.projectDetails.logo}</a></div>


### PR DESCRIPTION
The grid column has now auto width instead of fixed `fr`.

Removed the `projectLogo` class and moved its declarations to `tokenInfo` since it applies to both _Project Details_ and _Seed Details_.
Although `projectLogo` has now one extra column, I believe it is not an issue.

This fix refers to the following [issue](https://www.notion.so/curvelabs/Section-for-the-Token-Name-should-have-more-width-ec390c6a9dc1444cba141e58845b2622)