### PR TITLE
fixed typo

### DIFF
--- a/src/newSeed/stage4.html
+++ b/src/newSeed/stage4.html
@@ -166,7 +166,7 @@
 
               <p>Disallowed regions:
               
-              <p>Afghanistan, Cuba, Ethiopia, Guyana, Iran, Iraq, Koria, Sudan, Syria, United States, United States Minor Outlying Islands, Venezuela, Yemen, the Crimea.</p></p>"></question-mark>
+              <p>Afghanistan, Cuba, Ethiopia, Guyana, Iran, Iraq, North Korea, Sudan, Syria, United States, United States Minor Outlying Islands, Venezuela, Yemen, the Crimea.</p></p>"></question-mark>
             </div>
           </div>
           <div class="checkboxContainer" click.delegate="toggleGeoBlocking()">


### PR DESCRIPTION
This is part of the following [Issue](https://www.notion.so/curvelabs/Seed-Wizards-Page-4-Change-Tool-Tip-Texts-09a4703aadd341cb84d0dd77fff01998)

Fixed the typo in Koria->North Korea.

Text for `Whitelist` needs more clarification with @dkent600- 
What are the file types: `.xx and .xx formats` the file should be in?
