### PR TITLE
remove gap between title and text

### DIFF
--- a/src/home/home.scss
+++ b/src/home/home.scss
@@ -9,7 +9,7 @@
 
     &.nomiss {
       border-radius: 6px;
-      &.title {
+      & .title {
         margin-bottom: 0px;
       }
     }


### PR DESCRIPTION
Closed the gap between `Never miss a launch` and `Sign-up for the Prime Launch Newsletter...` in the homepage.

Closes this [issue](https://www.notion.so/curvelabs/close-the-gap-between-Never-miss-a-launch-and-sign-up-for-the-prime-launch-newsletter-627007453c4b491ba102553b51b13c4e)