### PR TITLE
removed unnecessary width declaration on mobile

### DIFF
--- a/src/home/home.scss
+++ b/src/home/home.scss
@@ -323,18 +323,3 @@
     }
   }
 }
-
-@media screen and (max-width: 420px) {
-  .page.home {
-    .section {
-      &.top {
-        .buttons {
-          .contribute,
-          .launch {
-            width: unset;
-          }
-        }
-      }
-    }
-  }
-}


### PR DESCRIPTION
Just find out that this `width` declaration on screen resolution width between 397px and 420px, caused to difference in buttons width:

![image](https://user-images.githubusercontent.com/2517870/126394425-f32c5798-3330-49be-ab7f-cee262dc4947.png)

I guess this media query can be removed now.