### PR TITLE
Disclaimer decline button text is not visible in Safari

### DIFF
--- a/src/newSeed/stage4.html
+++ b/src/newSeed/stage4.html
@@ -192,8 +192,8 @@
             value.bind="seedConfig.seedDetails.adminAddress"
             placeholder="Administrator wallet address" />
           <template if.to-view="!seedConfig.seedDetails.adminAddress">
-            <button class="button2 small" if.to-view="!ethereumService.defaultAccountAddress" click.delegate="connect()">Connect to get your wallet address</button>
-            <button class="button2 small" else click.delegate="makeMeAdmin()">I will be the administrator</button>
+            <div class="button2 small" if.to-view="!ethereumService.defaultAccountAddress" click.delegate="connect()">Connect to get your wallet address</div>
+            <div class="button2 small" else click.delegate="makeMeAdmin()">I will be the administrator</div>
           </template>
         </div>
         <div class="buttonContainer">

--- a/src/resources/dialogs/disclaimer/disclaimer.html
+++ b/src/resources/dialogs/disclaimer/disclaimer.html
@@ -9,8 +9,8 @@
     </ux-dialog-body>
     <ux-dialog-footer>
       <label><input type="checkbox" checked.bind="checked">I acknowledge that I have fully read and understood this disclaimer</label>
-      <button class="button2" click.trigger="controller.cancel(false)">Decline</button>
-      <button class="button1" disabled.to-view="!checked" ref="okButton" click.trigger="controller.ok(true)">Accept</button>
+      <div role="button" class="button2" click.trigger="controller.cancel(false)">Decline</div>
+      <div role="button" class="button1" disabled.to-view="!checked" ref="okButton" click.trigger="controller.ok(true)">Accept</div>
     </ux-dialog-footer>
   </ux-dialog>
 </template>

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -181,6 +181,7 @@ html {
     .button2 {
       @include standardTextGradient;
       border: solid 1px $Secondary02;
+      display: inline-block;
 
       &:hover {
         -webkit-text-fill-color: $Secondary04;


### PR DESCRIPTION
Apparently the -webkit-text-fill-color: transparent; is what’s failing in Safari, but only when used with a button tag. Once I change the button into a div tag (and set it to inline-block) it functions and looks correctly on chrome/safari/opera/edge/brave/firefox browsers.

I found this [issue](https://www.notion.so/curvelabs/Disclaimer-DECLINE-button-text-is-not-visible-in-Safari-16ef63b72fa0480296dedd79744cd998) affecting both the disclaimer and the stage4 page of the wizard.