### PR TITLE
fix disclaimer accept button too wide

### DIFF
--- a/src/resources/dialogs/disclaimer/disclaimer.html
+++ b/src/resources/dialogs/disclaimer/disclaimer.html
@@ -10,7 +10,7 @@
     <ux-dialog-footer>
       <label><input type="checkbox" checked.bind="checked">I acknowledge that I have fully read and understood this disclaimer</label>
       <div role="button" class="button2" click.trigger="controller.cancel(false)">Decline</div>
-      <div role="button" class="button1" disabled.to-view="!checked" ref="okButton" click.trigger="controller.ok(true)">Accept</div>
+      <button class="button1" disabled.to-view="!checked" ref="okButton" click.trigger="controller.ok(true)">Accept</button>
     </ux-dialog-footer>
   </ux-dialog>
 </template>

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -139,8 +139,10 @@ html {
 
     .button1,
     .button2 {
+      display: inline-block;
       border-radius: 50px;
       border: none;
+      margin: 5px 0 5px 5px;
       padding: 14px 28px;
       outline: none;
 
@@ -181,7 +183,6 @@ html {
     .button2 {
       @include standardTextGradient;
       border: solid 1px $Secondary02;
-      display: inline-block;
 
       &:hover {
         -webkit-text-fill-color: $Secondary04;


### PR DESCRIPTION
Fixed the accept button to have the same width as the decline button.

I have returned the accept `button` to be a native `button` element, as this is the most simple way to maintain the 'disabled' state that was lost too when converted into `div`.

I've added the two declarations:
```
display: inline-block;
margin: 5px 0 5px 5px;
```
they defined for the native `button` and should have been translated to the `div`-button too.
