### PR TITLE
converted link into a button

### DIFF
--- a/src/selectPackage/selectPackage.html
+++ b/src/selectPackage/selectPackage.html
@@ -30,7 +30,7 @@
               If successful
             </div>
           </div>
-          <a class="button button1" href="/newSeed">START REGISTRATION</a>
+          <a class="button1" href="/newSeed">START REGISTRATION</a>
           <div class="learnMore">
             <a>LEARN MORE</a>
           </div>

--- a/src/selectPackage/selectPackage.html
+++ b/src/selectPackage/selectPackage.html
@@ -30,9 +30,7 @@
               If successful
             </div>
           </div>
-          <button click.delegate="navigate('newSeed')" class="button button1">
-            START REGISTRATION
-          </button>
+          <a class="button button1" href="/newSeed">START REGISTRATION</a>
           <div class="learnMore">
             <a>LEARN MORE</a>
           </div>

--- a/src/selectPackage/selectPackage.html
+++ b/src/selectPackage/selectPackage.html
@@ -30,9 +30,9 @@
               If successful
             </div>
           </div>
-          <div class="button button1">
-            <a href="/newSeed">START REGISTRATION</a>
-          </div>
+          <button click.delegate="navigate('newSeed')" class="button button1">
+            START REGISTRATION
+          </button>
           <div class="learnMore">
             <a>LEARN MORE</a>
           </div>


### PR DESCRIPTION
This PR fixes the button behavior on the `Select Package` page- Should be a button and not a link.
Closes Issue #193.
