### PR TITLE
Chore: admin allow drop down

### DIFF
--- a/src/seedAdminDashboard/seedAdminDashboard.html
+++ b/src/seedAdminDashboard/seedAdminDashboard.html
@@ -18,7 +18,7 @@
         <div if.bind="seeds.length">
           <dropdown 
             class="seedsDropdown"
-            if.bind="!defaultSeedAddress || (seeds.length === 1)"
+            if.bind="seeds.length !== 1"
             item-changed.call="selectSeed(index)"
             selected-item-index.to-view="selectedSeedIndex"
             placeholder="Select a Seed...">
@@ -79,7 +79,7 @@
                 Retrieve Project Tokens
               </div>
               <div class="featureDescription">
-                There are ${convertProjectTokenAmount(selectedSeed.projectTokenBalance)} ${selectedSeed.projectTokenInfo.symbol} <img class="tokenImage" src.to-view="selectedSeed.projectTokenInfo.logoURI"></img> amount of Project Tokens which will be transferred to the address you mention below.
+                There are ${convertProjectTokenAmount(selectedSeed.projectTokenBalance.sub(selectedSeed.seedRemainder.add(selectedSeed.feeRemainder)))} ${selectedSeed.projectTokenInfo.symbol} <img class="tokenImage" src.to-view="selectedSeed.projectTokenInfo.logoURI"></img> amount of Project Tokens which will be transferred to the address you mention below.
               </div>
               <div>
                 <input id="receiverAddress" value.bind="receiverAddress" placeholder="0x6C4ef..." />
@@ -88,12 +88,12 @@
                 </div>
               </div>
             </div>
-            <div class="featureContainer" if.bind="selectedSeed.claimingIsOpen">
+            <div class="featureContainer" if.bind="selectedSeed.claimingIsOpen && selectedSeed.fundingTokenBalance != 0">
               <div class="featureTitle">
                 Withdraw Funding Tokens
               </div>
               <div class="featureDescription">
-                There are ${convertFundingTokenAmount(selectedSeed.amountRaised)} ${selectedSeed.fundingTokenInfo.symbol} <img class="tokenImage" src.to-view="selectedSeed.fundingTokenInfo.logoURI"></img> amount of funding tokens which will be transfered to admin address once you click Withdraw
+                There are ${convertFundingTokenAmount(selectedSeed.fundingTokenBalance)} ${selectedSeed.fundingTokenInfo.symbol} <img class="tokenImage" src.to-view="selectedSeed.fundingTokenInfo.logoURI"></img> amount of funding tokens which will be transfered to admin address once you click Withdraw
               </div>
               <div class="button1" click.delegate="selectedSeed.withdrawFundingTokens()">
                 Withdraw

--- a/src/seedAdminDashboard/seedAdminDashboard.ts
+++ b/src/seedAdminDashboard/seedAdminDashboard.ts
@@ -75,10 +75,10 @@ export class SeedAdminDashboard {
       this.seeds = [];
     }
     if (this.defaultSeedAddress) {
-      const defaultSeed = this.seeds.filter((seed) => seed.address === this.defaultSeedAddress);
-      if (defaultSeed.length === 1) {
-        this.selectedSeed = defaultSeed[0];
-        this.selectedSeedIndex = 0;
+      const defaultSeedIndex = this.seeds.map((seed,index) => this.defaultSeedAddress === seed.address ? index : undefined).filter((seed) => seed);
+      if (defaultSeedIndex.length === 1) {
+        this.selectedSeedIndex = defaultSeedIndex[0];
+        this.selectedSeed = this.seeds[defaultSeedIndex[0]];
       }
     }
   }


### PR DESCRIPTION
Optional:
If we want to not display drop down only when the user have created only single seed.
But if the admin have created multiple seed, we display a drop down. It doesn't matter if they access using `admin/seeds/dashboard` or `admin/seeds/dashboard/0x9f13D7D0cc9f4f5555cc34Ce6AB49c0bbD0c2f4f`. They should see a drop down.

Only if this functionality was intended.
