### PR TITLE
nicer spinny icon for token select dropdown

### DIFF
--- a/src/resources/elements/tokenSelect/tokenSelect.html
+++ b/src/resources/elements/tokenSelect/tokenSelect.html
@@ -3,7 +3,7 @@
   <dropdown class="tokenSelect"
     item-changed.call="setSelectedToken(value,index)"
     selected-item-index.to-view="selectedTokenIndex"
-    placeholder.bind="!tokenInfos?'<i class=\'spinner fas fa-circle-notch fa-spin\'></i>&nbsp;Loading...':'Select a token...'">
+    placeholder.bind="tokenInfos?'<span class=\'placeholder\'><i class=\'spinner fas fa-circle-notch fa-spin\'></i><span>Loading...</span></span>':'Select a token...'">
     <div repeat.for="tokenInfo of tokenInfos">
       <div class="tokenItem">
         <div><img src.to-view="tokenInfo.logoURI"></img></div>

--- a/src/resources/elements/tokenSelect/tokenSelect.scss
+++ b/src/resources/elements/tokenSelect/tokenSelect.scss
@@ -4,6 +4,18 @@
   .dropdown {
     width: 300px;
   }
+
+  .placeholder {
+    display: grid;
+    grid-template-columns: 1fr 16px;
+    column-gap: 10px;
+    align-items: center;
+    justify-content: left;
+    .spinner {
+      color: $Secondary03-dev;
+    }
+  }
+
   .tokenItem {
     display: flex;
     align-items: center;


### PR DESCRIPTION
See #245 

Looking at common UI's, might make sense to refactor the drop down to have a `loading` state, and replace the spinner with the `arrow` icon on the right, while loading.
Currently it's impossible to implement since the loading state applies only to the `select-token` element.

Suggested as an optional change...