### PR TITLE
Fix/mobile geoblock

### DIFF
--- a/src/newLaunch/baseStage.scss
+++ b/src/newLaunch/baseStage.scss
@@ -709,6 +709,10 @@
       line-height: 20px;
       margin-bottom: 5px;
     }
+
+    #geoBlock+label {
+      margin-bottom: unset;
+    }
     .summaryContainer {
       margin-bottom: 30px;
       word-break: break-word;

--- a/src/newLaunch/baseStage.scss
+++ b/src/newLaunch/baseStage.scss
@@ -574,7 +574,7 @@
           width: 22px;
           height: 22px;
           position: absolute;
-          left: 2px;
+          left: 4px;
           background: white;
           border-radius: 50%;
           transition: all 0.3s ease;


### PR DESCRIPTION
See #244 

1. On mobile labels have 5px margin. @dkent600 is it necessary? For this issue I've removed the margin only from the `geoBlock` label, but if not needed, it can be removed globally- what caused this issue in the first place.
2. I've also added a small fix to the left-position of the toggle-handle (applies all screen sizes).