### PR TITLE
Reduce spacing for `Vesting Schedule` sub titles

### DIFF
--- a/src/newLaunch/baseStage.scss
+++ b/src/newLaunch/baseStage.scss
@@ -436,7 +436,8 @@
         gap: 32px;
         &.maxTargetLabel label {
           font-size: 14px;
-          line-height: 48px;
+          line-height: 20px;
+          margin-bottom: 5px;
           -webkit-text-fill-color: $White;
           font-weight: 400;
         }


### PR DESCRIPTION
Reduced spacing for subtitles to match with the general design.

![image](https://user-images.githubusercontent.com/2517870/137123484-870d551c-3545-4608-8050-3a26b8fd33d9.png)
