### PR TITLE
Social media links layout

### DIFF
--- a/src/launchAbout/launchAbout.scss
+++ b/src/launchAbout/launchAbout.scss
@@ -30,6 +30,7 @@
       margin-bottom: 16px;
       display: flex;
       align-items: baseline;
+      flex: 1 170px;
 
       &:hover {
         text-decoration: none;
@@ -115,8 +116,7 @@
     }
 
     .links {
-      margin: 0 10%;
-      flex-direction: column;
+      margin: 0 10% 30px;
 
       a {
         justify-content: center;
@@ -138,7 +138,7 @@
   }
 }
 
-@media screen and (max-width: 620px) {
+@media screen and (max-width: 571px) {
   .launchAbout {
     .links {
       a {


### PR DESCRIPTION
Increased bottom space between links section
sorry, missing screenshots attached:
![image](https://user-images.githubusercontent.com/85691163/138661305-dc7a4c95-e32d-4f25-9202-e3597414d65d.png)
![image](https://user-images.githubusercontent.com/85691163/138661453-54574238-4410-4dec-8304-3eba327dabd0.png)
![image](https://user-images.githubusercontent.com/85691163/138661521-0dfec43a-13fd-4385-8f3a-e96de7e8d750.png)
