### PR TITLE
364- Sidebar Lines need to be centered

### DIFF
--- a/src/newLaunch/launch.scss
+++ b/src/newLaunch/launch.scss
@@ -22,12 +22,12 @@
     }
   }
   .currentStageSidebar {
-    line-height: 2rem;
-    font-size: 1.125rem;
+    line-height: 32px;
+    font-size: 18px;
     font-family: Inter;
     font-weight: 300;
     color: $Neutral02;
-    padding: 5rem 1rem;
+    padding: 80px 16px;
     .currentstage {
       cursor: pointer;
     }
@@ -36,20 +36,20 @@
     }
     .stagesNumber {
       display: flex;
-      gap: 1em;
+      gap: 16px;
       flex-flow: row nowrap;
       align-items: center;
     }
     .timeLine {
-      width: 42px;
+      width: 40px;
       height: 20.8px;
       display: grid;
       justify-content: center;
-      padding-top: 0.15em;
-      padding-bottom: 0.15em;
+      padding-top: 2.4px;
+      padding-bottom: 2.4px;
       .ruler {
-        width: 0.23em;
-        height: 1.3em;
+        width: 3.75px;
+        height: 20.8px;
         background-color: $Neutral02;
       }
     }
@@ -74,12 +74,11 @@
       padding-bottom: 32px;
       display: none;
       .timeLine {
-        width: 40px;
         height: 3px;
         display: grid;
         justify-content: center;
         .ruler {
-          width: 4px;
+          width: 3.75px;
           height: 4px;
           background-color: $Neutral02;
         }

--- a/src/resources/elements/circledNumber/circledNumber.scss
+++ b/src/resources/elements/circledNumber/circledNumber.scss
@@ -1,10 +1,13 @@
 @import "styles/colors.scss";
+
+$Radius: 40px;
+
 .circledNumber {
   border-radius: 50%;
   text-align: center;
   background-color: $Neutral02;
-  min-width: 41.6px;
-  height: 40px;
+  width: $Radius;
+  height: $Radius;
   &.active {
     background-color: $Secondary02;
   }
@@ -13,9 +16,6 @@
     font-family: Inter;
     font-weight: 600;
     font-size: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
+    line-height: $Radius;
   }
 }


### PR DESCRIPTION
Missed this fix on mobile view in last PR - On mobile the rulers was still a little off.
In addition, the following changes have been done:
* Converted `em`s to `px`.
* Made the circle round - w+h: 40px.
* A little cleanup for CSS.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <p>
        <img src="https://user-images.githubusercontent.com/2517870/139530318-fd84e77e-a68e-46cc-9b02-6361fce327ed.png" width="200" />
      </p>
      <p>
        <img src="https://user-images.githubusercontent.com/2517870/139530373-00c65a1d-8716-422f-b067-103be226f220.png" width="200" />
      </p>
    </td>
    <td>
      <p>
        <img src="https://user-images.githubusercontent.com/2517870/139530314-c675b925-ed78-4d18-a4fe-b4de40e8e56c.png" width="200">
      </p>
      <p>
        <img src="https://user-images.githubusercontent.com/2517870/139530377-96815c46-82a8-4e0c-8ecf-73117f85cb41.png" width="200">
      </p>
    </td>
  </tr>
</table>

