### PR TITLE
Remove vestingDateContainer to fix the vertical align bug

### DIFF
--- a/src/newLaunch/lbp/stages/stage4.html
+++ b/src/newLaunch/lbp/stages/stage4.html
@@ -128,20 +128,17 @@
                 <question-mark text="Please note that a Liquidity Bootstrapping Pool cannot last longer than 30 days"></question-mark>
               </div>
             </div>
-            <div class="vestingDatesContainer">
-              <div class="vestingDates">
-                <input
-                  id="endDate"
-                  class="vestingDateInput"
-                  value.bind="endDate | date"
-                  placeholder="YYYY-MM-DD"
-                  ref="endDateRef"
-                  click.delegate="endDatePicker.show()"
-                  autocomplete="off" disabled />
-                <div class="inputIcon"><i class="far fa-calendar-alt" click.delegate="endDatePicker.show()"></i></div>
-              </div>
+            <div class="vestingDates">
+              <input
+                id="endDate"
+                class="vestingDateInput"
+                value.bind="endDate | date"
+                placeholder="YYYY-MM-DD"
+                ref="endDateRef"
+                click.delegate="endDatePicker.show()"
+                autocomplete="off" disabled />
+              <div class="inputIcon"><i class="far fa-calendar-alt" click.delegate="endDatePicker.show()"></i></div>
             </div>
-            
           </div>
           <div>
             <div class="labeledQuestion">


### PR DESCRIPTION
The Vesting Date's additional container has been removed now. 

## Screenshots

### Seeds:
<img width="480" alt="Screenshot 2021-11-01 at 7 36 02 PM" src="https://user-images.githubusercontent.com/32637757/139684548-8b4abded-483f-43d1-aa16-ee82aaa933f0.png">

### LBP:
<img width="631" alt="Screenshot 2021-11-01 at 7 37 18 PM" src="https://user-images.githubusercontent.com/32637757/139684740-1487f0dc-4af2-47c5-94a7-c5731973394c.png">