### PR TITLE
build: provide empty polyfill for fs in webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,6 +65,9 @@ module.exports = ({ production } = {}, { extractCss, analyze, tests, hmr, port, 
       'aurelia-bootstrapper'
     ]
   },
+  node: {
+    fs: "empty"
+  },
   mode: production ? 'production' : 'development',
   output: {
     path: outDir,


### PR DESCRIPTION
We've had no troubles using the SOR in the browser and I noticed that you're running on an older version of webpack.

This seems to be a [known issue](https://github.com/webpack-contrib/css-loader/issues/447) and I've included a fix.