### PR TITLE
chore: remove copy for documentation redirect

### DIFF
--- a/src/seedDashboard/seedDashboard.html
+++ b/src/seedDashboard/seedDashboard.html
@@ -50,7 +50,7 @@
         <div if.to-view="!connected && !geoBlocked" class="section section1">
           <div class="description">Check eligibility</div>
           <div class="help">
-            <question-mark text="Check if your address is eligibile to participate in this Seed. You can learn more about the Prime Launch whitelist process here"></question-mark>
+            <question-mark text="Check if your address is eligibile to participate in this Seed."></question-mark>
           </div>
           <div class="subdescription subtext">Connect your wallet to contribute and claim rewards</div>
           <div class="doit"><button class="button1" click.delegate="connect()">CONNECT</button></div>


### PR DESCRIPTION
The Seed Dashboard for a particular launches' eligibility card now does not have the mentioned redirection.


## Screenshots

### Seed  Dashboard "Connect to Wallet card"
<img width="872" alt="Screenshot 2021-11-03 at 5 33 13 PM" src="https://user-images.githubusercontent.com/32637757/140056580-36f6d862-b968-43a5-a921-f23d37d123e3.png">
