### PR TITLE
chore: reduce font size over stages numbers

### DIFF
--- a/src/newLaunch/launch.scss
+++ b/src/newLaunch/launch.scss
@@ -39,10 +39,6 @@
       gap: 16px;
       flex-flow: row nowrap;
       align-items: center;
-
-      .value {
-        font-size: 18px;
-      }
     }
     .timeLine {
       width: 40px;
@@ -85,6 +81,11 @@
           width: 3.75px;
           height: 4px;
           background-color: $Neutral02;
+        }
+      }
+      .stagesNumber {
+        .value {
+          font-size: 18px;
         }
       }
     }

--- a/src/newLaunch/launch.scss
+++ b/src/newLaunch/launch.scss
@@ -39,6 +39,10 @@
       gap: 16px;
       flex-flow: row nowrap;
       align-items: center;
+
+      .value {
+        font-size: 18px;
+      }
     }
     .timeLine {
       width: 40px;


### PR DESCRIPTION
The sidebar numbers' font size is now a bit smaller

## Screenshots

New LBP (Desktop)
<img width="1067" alt="Screenshot 2021-11-03 at 6 13 08 PM" src="https://user-images.githubusercontent.com/32637757/140062016-0b924869-5bcb-4c1f-8bd8-5cdb588638cc.png">

New LBP (Mobile)
<img width="375" alt="Screenshot 2021-11-03 at 6 13 39 PM" src="https://user-images.githubusercontent.com/32637757/140062079-5d6ee60b-8f22-47df-9058-b7e9b9242b3f.png">

New Seed (Desktop)
<img width="1038" alt="Screenshot 2021-11-03 at 6 15 00 PM" src="https://user-images.githubusercontent.com/32637757/140062280-a2be2add-13bf-4d7a-8a90-aedc512518a4.png">


New Seed (Mobile)
<img width="370" alt="Screenshot 2021-11-03 at 6 14 20 PM" src="https://user-images.githubusercontent.com/32637757/140062213-72caeaa1-fce8-4182-9695-130110b39614.png">
