### PR TITLE
306- Primedao legal disclaimer button should have the same height

### DIFF
--- a/src/resources/dialogs/dialogs.scss
+++ b/src/resources/dialogs/dialogs.scss
@@ -85,6 +85,12 @@ body > ux-dialog-container {
       .checkbox {
         margin-right: 10px;
       }
+      .action-buttons {
+        display: inline-flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: flex-end;
+      }
       .bodyContainer {
         white-space: pre-wrap;
         word-break: break-word;
@@ -128,6 +134,9 @@ body > ux-dialog-overlay {
         display: flex;
         flex-direction: column;
         text-align: center;
+        .action-buttons {
+          justify-content: center;
+        }
       }
     }
   }

--- a/src/resources/dialogs/disclaimer/disclaimer.html
+++ b/src/resources/dialogs/disclaimer/disclaimer.html
@@ -9,8 +9,10 @@
     </ux-dialog-body>
     <ux-dialog-footer>
       <label><input type="checkbox" class="checkbox" checked.bind="checked">I acknowledge that I have fully read and understood this disclaimer</label>
-      <div role="button" class="button2" click.trigger="controller.cancel(false)">Decline</div>
-      <button class="button1" disabled.to-view="!checked" ref="okButton" click.trigger="controller.ok(true)">Accept</button>
+      <div class="action-buttons">
+        <div role="button" class="button2" click.trigger="controller.cancel(false)">Decline</div>
+        <button class="button1" disabled.to-view="!checked" ref="okButton" click.trigger="controller.ok(true)">Accept</button>
+      </div>
     </ux-dialog-footer>
   </ux-dialog>
 </template>

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -224,6 +224,7 @@ html {
     .button2 {
       @include standardTextGradient;
       border: solid 1px $Secondary02;
+      padding: 13px 28px;
 
       &:hover {
         -webkit-text-fill-color: $Secondary04;


### PR DESCRIPTION
Fixes height of "decline" button (.button2)
Align action buttons vertically centered.

Result:
Large screen:
![image](https://user-images.githubusercontent.com/2517870/140601934-63760135-c07f-4443-8288-ebbe8fdf8278.png)

Medium screen:
![image](https://user-images.githubusercontent.com/2517870/140601946-81c33435-f690-4e50-a1d4-5fa1b7e11c87.png)

Small screen:
![image](https://user-images.githubusercontent.com/2517870/140601957-1f96a487-7b34-4b7e-a07c-1978e5a0e137.png)
