### PR TITLE
653 - Display the preview chart on the lbp dashboard until launch begins

### DIFF
--- a/src/lbpDashboard/lbpPriceChart/lbpPriceChart.html
+++ b/src/lbpDashboard/lbpPriceChart/lbpPriceChart.html
@@ -2,6 +2,6 @@
   <require from="resources/elements/sparkChart/spark-chart"></require>
   <div class="graph">
     <div show.to-view="!lbpMgr.priceHistory" class="loading"><i class="fas fa-circle-notch fa-spin"></i></div>
-    <spark-chart if.bind="graphConfig" chart-config.bind="graphConfig" grid-horizontal="true" height="400"></spark-chart>
+    <spark-chart if.bind="graphConfig" timescale-border chart-config.bind="graphConfig" grid-horizontal="true" height="400"></spark-chart>
   </div>
 </template>

--- a/src/lbpDashboard/lbpPriceChart/lbpPriceChart.ts
+++ b/src/lbpDashboard/lbpPriceChart/lbpPriceChart.ts
@@ -89,7 +89,8 @@ export class LbpPriceChart {
         };
       });
 
-      const futureForecast = forecast?.filter((item) => item.time > (history[history.length - 1]?.time));
+      const forecastStartTime = history[history.length - 1]?.time|| new Date().getTime() / 1000;
+      const futureForecast = forecast?.filter((item) => item.time > forecastStartTime);
 
       this.graphConfig = [
         {

--- a/src/services/ProjectTokenHistoricalPriceService.ts
+++ b/src/services/ProjectTokenHistoricalPriceService.ts
@@ -222,7 +222,7 @@ export class ProjectTokenHistoricalPriceService {
      * calculated forecast to the end of the array up to the current time.
      */
     const forecastData = await this.getTrajectoryForecastData(lbpMgr);
-    const pastForecast = forecastData?.filter((item) => item.time < (currentTime));
+    const pastForecast = forecastData?.filter((item) => item.time < currentTime);
     returnArray.pop(); // avoid duplicate last item
     return [...returnArray, ...pastForecast];
   }
@@ -243,7 +243,7 @@ export class ProjectTokenHistoricalPriceService {
     const prices = await this.getFundingTokenUSDPricesByID(
       lbpMgr.fundingTokenInfo.id,
       endTimeSeconds,
-      startTimeSeconds < currentTime ? startTimeSeconds : Math.floor(currentTime) - 3600,
+      (startTimeSeconds < currentTime) ? startTimeSeconds : (Math.floor(currentTime) - 3600),
       intervalMinutes,
     );
 

--- a/src/services/ProjectTokenHistoricalPriceService.ts
+++ b/src/services/ProjectTokenHistoricalPriceService.ts
@@ -73,7 +73,7 @@ export class ProjectTokenHistoricalPriceService {
    * @returns Array(IHistoricalPriceRecord): {time: number, price?: number}
    */
   public async getPricesHistory(lbpMgr: LbpManager): Promise<Array<IHistoricalPriceRecord>> {
-    if (!lbpMgr.lbp || !lbpMgr.lbp.poolId || lbpMgr.startTime.getTime() >= new Date().getTime()) {
+    if (!lbpMgr.lbp || !lbpMgr.lbp.poolId || lbpMgr.hasNotStarted) {
       return [];
     }
 
@@ -113,7 +113,7 @@ export class ProjectTokenHistoricalPriceService {
     const prices = await this.getFundingTokenUSDPricesByID(
       lbpMgr.fundingTokenInfo.id,
       endTimeSeconds,
-      startTimeSeconds < new Date().getTime() / 1000 ? startTimeSeconds : Math.floor(new Date().getTime() / 1000) - 3600,
+      startTimeSeconds < currentTime ? startTimeSeconds : Math.floor(currentTime) - 3600,
       intervalMinutes,
     );
 
@@ -222,7 +222,7 @@ export class ProjectTokenHistoricalPriceService {
      * calculated forecast to the end of the array up to the current time.
      */
     const forecastData = await this.getTrajectoryForecastData(lbpMgr);
-    const pastForecast = forecastData?.filter((item) => item.time < (new Date().getTime() / 1000));
+    const pastForecast = forecastData?.filter((item) => item.time < (currentTime));
     returnArray.pop(); // avoid duplicate last item
     return [...returnArray, ...pastForecast];
   }
@@ -243,7 +243,7 @@ export class ProjectTokenHistoricalPriceService {
     const prices = await this.getFundingTokenUSDPricesByID(
       lbpMgr.fundingTokenInfo.id,
       endTimeSeconds,
-      startTimeSeconds < new Date().getTime() / 1000 ? startTimeSeconds : Math.floor(new Date().getTime() / 1000) - 3600,
+      startTimeSeconds < currentTime ? startTimeSeconds : Math.floor(currentTime) - 3600,
       intervalMinutes,
     );
 
@@ -256,7 +256,7 @@ export class ProjectTokenHistoricalPriceService {
       lbpMgr.projectTokenEndWeight,
     );
 
-    const lastSwapDate = this.dateService.ticksToDate(Math.floor(lastSwap.timestamp / 3600) * 3600 * 1000);
+    const lastSwapDate = this.dateService.ticksToDate(lastSwap.timestamp * 1000);
     const poolPTBalance = this.numberService.fromString(fromWei(lbpMgr.lbp.vault.projectTokenBalance, lbpMgr.projectTokenInfo.decimals));
     const poolFTBalance = this.numberService.fromString(fromWei(lbpMgr.lbp.vault.fundingTokenBalance, lbpMgr.fundingTokenInfo.decimals));
     const projectTokenAmount = this.numberService.fromString(lastSwap.tokenAmountOut);


### PR DESCRIPTION
Fixed the chart issue- shows now the trajectory data for launches that haven't started yet.

Added fix to the timescale formatting with the following logic:
Under 24h duration: "H:mm" (5:00)
Under 5 days duration: "MMM DD | H:mm" (Dec 10 | 17:00)
Above 5 days duration: "MMM DD" (Dec 10)

Added Border to the timescale at bottom of the chart (Dashboard only!)
Removed the border from the price scale at the right - Previously, it was in an undefined color. (Coordinated with @renc-curvelabs )

Result: (Mainnet | D2D launch)
![image](https://user-images.githubusercontent.com/2517870/145610542-93b63cd6-ad5d-4a86-b431-e6d73cf0fcc9.png)

![image](https://user-images.githubusercontent.com/2517870/145611128-eafa2d5f-4679-46b0-8051-719b86fbe106.png)

![image](https://user-images.githubusercontent.com/2517870/145611275-e1ccdff6-2199-4970-8328-ee8d33c37eaf.png)
