### PR TITLE
688 - Time left display (fix and feature change)

### DIFF
--- a/src/lbpDashboard/projectTokenInfo/projectTokenInfo.html
+++ b/src/lbpDashboard/projectTokenInfo/projectTokenInfo.html
@@ -10,7 +10,7 @@
       $ <formatted-number thousands-separated value.bind="currentPrice"></formatted-number>
     </div>
     <div class="timeleft">
-      <time-left launch.to-view="lbpMgr"></time-left>
+      <time-left launch.to-view="lbpMgr" largest></time-left>
     </div>
     <div class="priceChange ${(fundingTokenTrend > 0) ? 'increased' : ((fundingTokenTrend < 0) ? 'decreased' : '') }">
       <div class="sign">${fundingTokenTrendSign === '' ? '' : '$ '}${fundingTokenTrendSign}</div>

--- a/src/services/DateService.ts
+++ b/src/services/DateService.ts
@@ -1,4 +1,4 @@
-import { autoinject } from "aurelia-framework";
+﻿import { autoinject } from "aurelia-framework";
 import * as moment from "moment-timezone";
 import Moment = moment.Moment;
 
@@ -214,7 +214,7 @@ export class DateService {
     }
 
     let firstResolution = false;
-    let stop = false;
+    let largestTwoCounter = 0;
 
     const days = Math.floor(ms / 86400000);
     ms = ms % 86400000;
@@ -232,13 +232,13 @@ export class DateService {
       result = `${days}${abbrev ? "d" : (days === 1 ? " day" : " days")}`;
 
       if (largest) {
-        stop = true;
+        largestTwoCounter += 1;
       } else {
         firstResolution = true;
       }
     }
 
-    if (!stop && ((hours ||
+    if (!shouldStopOnLargest2(largestTwoCounter) && ((hours ||
       // show zero if not the first or is the res
       firstResolution ||
       (resolution === TimespanResolution.hours)) &&
@@ -247,13 +247,13 @@ export class DateService {
       result += `${result.length ? ", " : ""}${hours}${abbrev ? "h" : (hours === 1 ? " hour" : " hours")}`;
 
       if (largest) {
-        stop = true;
+        largestTwoCounter += 1;
       } else {
         firstResolution = true;
       }
     }
 
-    if (!stop && ((minutes ||
+    if (!shouldStopOnLargest2(largestTwoCounter) && ((minutes ||
       // show zero if not the first or is the res
       firstResolution ||
       (resolution === TimespanResolution.minutes)) &&
@@ -262,26 +262,26 @@ export class DateService {
       result += `${result.length ? ", " : ""}${minutes}${abbrev ? "m" : (minutes === 1 ? " minute" : " minutes")}`;
 
       if (largest) {
-        stop = true;
+        largestTwoCounter += 1;
       }
       // else {
       //   firstResolution = true;
       // }
     }
 
-    if (!stop && (resolution <= TimespanResolution.seconds)) {
+    if (!shouldStopOnLargest2(largestTwoCounter) && resolution <= TimespanResolution.seconds) {
 
       result += `${result.length ? ", " : ""}${seconds}${abbrev ? "s" : (seconds === 1 ? " second" : " seconds")}`;
 
       if (largest) {
-        stop = true;
+        largestTwoCounter += 1;
       }
       // else {
       //   firstResolution = true;
       // }
     }
 
-    if (!stop && (ms && (resolution === TimespanResolution.milliseconds))) {
+    if (!shouldStopOnLargest2(largestTwoCounter) && (ms && (resolution === TimespanResolution.milliseconds))) {
       result += `${result.length ? ", " : ""}${ms}${abbrev ? "ms" : (ms === 1 ? " millisecond" : " milliseconds")}`;
     }
 
@@ -452,6 +452,10 @@ export class DateService {
   }
 }
 
+function shouldStopOnLargest2(largestCounter: number) {
+  return largestCounter === 2;
+}
+
 interface IFormat {
   key: string;
   format: string;
@@ -465,7 +469,7 @@ export interface IFormatParameters {
 
 export enum TimespanResolution {
   /**
-   * show only the largest unit, down to the resolution or'd with this
+   * show only the largest 2 units, down to the resolution or'd with this
    */
   largest = 0x20,
   days = 0x10,

--- a/src/services/DateService.ts
+++ b/src/services/DateService.ts
@@ -1,4 +1,4 @@
-﻿import { autoinject } from "aurelia-framework";
+import { autoinject } from "aurelia-framework";
 import * as moment from "moment-timezone";
 import Moment = moment.Moment;
 
@@ -119,17 +119,17 @@ export class DateService {
 
   /**
    * input and output are in milliseconds
-   * @param ts 
-   * @returns 
+   * @param ts
+   * @returns
    */
-    public translateUtcTimestampToLocal(ts: number): number {
+  public translateUtcTimestampToLocal(ts: number): number {
     return ts - (this.localTimezoneOffset * 60 * 1000);
   }
 
   /**
-   * 
+   *
    * @param ts input and output are in milliseconds
-   * @returns 
+   * @returns
    */
   public translateLocalTimestampToUtc(ts: number): number {
     return ts + (this.localTimezoneOffset * 60 * 1000);

--- a/test/unit/services/DateService.spec.ts
+++ b/test/unit/services/DateService.spec.ts
@@ -22,6 +22,23 @@ describe("DateService", () => {
   describe("#ticksToTimeSpanString", () => {
     /* prettier-ignore */
     const testData: TestData[] = [
+      [TimespanResolution.largest, [1, 1, 1, 1], "1 day, 1 hour"],
+      [TimespanResolution.largest, [1, 1, 1, 0], "1 day, 1 hour"],
+      [TimespanResolution.largest, [1, 1, 0, 1], "1 day, 1 hour"],
+      [TimespanResolution.largest, [1, 1, 0, 0], "1 day, 1 hour"],
+      [TimespanResolution.largest, [1, 0, 1, 1], "1 day, 1 minute"],
+      [TimespanResolution.largest, [1, 0, 1, 0], "1 day, 1 minute"],
+      [TimespanResolution.largest, [1, 0, 0, 1], "1 day, 1 second"],
+      [TimespanResolution.largest, [1, 0, 0, 0], "1 day, 0 seconds"],
+      [TimespanResolution.largest, [0, 1, 1, 1], "1 hour, 1 minute"],
+      [TimespanResolution.largest, [0, 1, 1, 0], "1 hour, 1 minute"],
+      [TimespanResolution.largest, [0, 1, 0, 1], "1 hour, 1 second"],
+      [TimespanResolution.largest, [0, 1, 0, 0], "1 hour, 0 seconds"],
+      [TimespanResolution.largest, [0, 0, 1, 1], "1 minute, 1 second"],
+      [TimespanResolution.largest, [0, 0, 1, 0], "1 minute, 0 seconds"],
+      [TimespanResolution.largest, [0, 0, 0, 1], "1 second"],
+      [TimespanResolution.largest, [0, 0, 0, 0], "0 seconds"],
+
       [TimespanResolution.days, [1, 1, 1, 1], "1 day"],
       [TimespanResolution.days, [1, 1, 1, 0], "1 day"],
       [TimespanResolution.days, [1, 1, 0, 1], "1 day"],

--- a/test/unit/services/DateService.spec.ts
+++ b/test/unit/services/DateService.spec.ts
@@ -1,0 +1,115 @@
+import { DateService, TimespanResolution } from "services/DateService";
+
+
+type TimeArray = [
+  days: number,
+  hours: number,
+  minutes: number,
+  seconds: number
+];
+type TestData = [
+  resolution: TimespanResolution,
+  timeArray: TimeArray,
+  expected: string
+];
+
+describe("DateService", () => {
+  let dateService: DateService;
+  beforeAll(() => {
+    dateService = new DateService();
+  });
+
+  describe("#ticksToTimeSpanString", () => {
+    /* prettier-ignore */
+    const testData: TestData[] = [
+      [TimespanResolution.days, [1, 1, 1, 1], "1 day"],
+      [TimespanResolution.days, [1, 1, 1, 0], "1 day"],
+      [TimespanResolution.days, [1, 1, 0, 1], "1 day"],
+      [TimespanResolution.days, [1, 1, 0, 0], "1 day"],
+      [TimespanResolution.days, [1, 0, 1, 1], "1 day"],
+      [TimespanResolution.days, [1, 0, 1, 0], "1 day"],
+      [TimespanResolution.days, [1, 0, 0, 1], "1 day"],
+      [TimespanResolution.days, [1, 0, 0, 0], "1 day"],
+      [TimespanResolution.days, [0, 1, 1, 1], ""],
+      [TimespanResolution.days, [0, 1, 1, 0], ""],
+      [TimespanResolution.days, [0, 1, 0, 1], ""],
+      [TimespanResolution.days, [0, 1, 0, 0], ""],
+      [TimespanResolution.days, [0, 0, 1, 1], ""],
+      [TimespanResolution.days, [0, 0, 1, 0], ""],
+      [TimespanResolution.days, [0, 0, 0, 1], ""],
+      [TimespanResolution.days, [0, 0, 0, 0], ""],
+
+      [TimespanResolution.hours, [1, 1, 1, 1], "1 day, 1 hour"],
+      [TimespanResolution.hours, [1, 1, 1, 0], "1 day, 1 hour"],
+      [TimespanResolution.hours, [1, 1, 0, 1], "1 day, 1 hour"],
+      [TimespanResolution.hours, [1, 1, 0, 0], "1 day, 1 hour"],
+      [TimespanResolution.hours, [1, 0, 1, 1], "1 day, 0 hours"],
+      [TimespanResolution.hours, [1, 0, 1, 0], "1 day, 0 hours"],
+      [TimespanResolution.hours, [1, 0, 0, 1], "1 day, 0 hours"],
+      [TimespanResolution.hours, [1, 0, 0, 0], "1 day, 0 hours"],
+      [TimespanResolution.hours, [0, 1, 1, 1], "1 hour"],
+      [TimespanResolution.hours, [0, 1, 1, 0], "1 hour"],
+      [TimespanResolution.hours, [0, 1, 0, 1], "1 hour"],
+      [TimespanResolution.hours, [0, 1, 0, 0], "1 hour"],
+      [TimespanResolution.hours, [0, 0, 1, 1], "0 hours"],
+      [TimespanResolution.hours, [0, 0, 1, 0], "0 hours"],
+      [TimespanResolution.hours, [0, 0, 0, 1], "0 hours"],
+      [TimespanResolution.hours, [0, 0, 0, 0], "0 hours"],
+
+      [TimespanResolution.minutes, [1, 1, 1, 1], "1 day, 1 hour, 1 minute"],
+      [TimespanResolution.minutes, [1, 1, 1, 0], "1 day, 1 hour, 1 minute"],
+      [TimespanResolution.minutes, [1, 1, 0, 1], "1 day, 1 hour, 0 minutes"],
+      [TimespanResolution.minutes, [1, 1, 0, 0], "1 day, 1 hour, 0 minutes"],
+      [TimespanResolution.minutes, [1, 0, 1, 1], "1 day, 0 hours, 1 minute"],
+      [TimespanResolution.minutes, [1, 0, 1, 0], "1 day, 0 hours, 1 minute"],
+      [TimespanResolution.minutes, [1, 0, 0, 1], "1 day, 0 hours, 0 minutes"],
+      [TimespanResolution.minutes, [1, 0, 0, 0], "1 day, 0 hours, 0 minutes"],
+      [TimespanResolution.minutes, [0, 1, 1, 1], "1 hour, 1 minute"],
+      [TimespanResolution.minutes, [0, 1, 1, 0], "1 hour, 1 minute"],
+      [TimespanResolution.minutes, [0, 1, 0, 1], "1 hour, 0 minutes"],
+      [TimespanResolution.minutes, [0, 1, 0, 0], "1 hour, 0 minutes"],
+      [TimespanResolution.minutes, [0, 0, 1, 1], "1 minute"],
+      [TimespanResolution.minutes, [0, 0, 1, 0], "1 minute"],
+      [TimespanResolution.minutes, [0, 0, 0, 1], "0 minutes"],
+      [TimespanResolution.minutes, [0, 0, 0, 0], "0 minutes"],
+
+      [TimespanResolution.seconds, [1, 1, 1, 1], "1 day, 1 hour, 1 minute, 1 second"],
+      [TimespanResolution.seconds, [1, 1, 1, 0], "1 day, 1 hour, 1 minute, 0 seconds"],
+      [TimespanResolution.seconds, [1, 1, 0, 1], "1 day, 1 hour, 0 minutes, 1 second"],
+      [TimespanResolution.seconds, [1, 1, 0, 0], "1 day, 1 hour, 0 minutes, 0 seconds"],
+      [TimespanResolution.seconds, [1, 0, 1, 1], "1 day, 0 hours, 1 minute, 1 second"],
+      [TimespanResolution.seconds, [1, 0, 1, 0], "1 day, 0 hours, 1 minute, 0 seconds"],
+      [TimespanResolution.seconds, [1, 0, 0, 1], "1 day, 0 hours, 0 minutes, 1 second"],
+      [TimespanResolution.seconds, [1, 0, 0, 0], "1 day, 0 hours, 0 minutes, 0 seconds"],
+      [TimespanResolution.seconds, [0, 1, 1, 1], "1 hour, 1 minute, 1 second"],
+      [TimespanResolution.seconds, [0, 1, 1, 0], "1 hour, 1 minute, 0 seconds"],
+      [TimespanResolution.seconds, [0, 1, 0, 1], "1 hour, 0 minutes, 1 second"],
+      [TimespanResolution.seconds, [0, 1, 0, 0], "1 hour, 0 minutes, 0 seconds"],
+      [TimespanResolution.seconds, [0, 0, 1, 1], "1 minute, 1 second"],
+      [TimespanResolution.seconds, [0, 0, 1, 0], "1 minute, 0 seconds"],
+      [TimespanResolution.seconds, [0, 0, 0, 1], "1 second"],
+      [TimespanResolution.seconds, [0, 0, 0, 0], "0 seconds"],
+    ];
+
+    testData.forEach(([resolution, timeArray, expected]) => {
+      it(`${timeArray} (${TimespanResolution[resolution]})`, () => {
+        const asMs = DateTestHelper.toMs(timeArray);
+        const result = dateService.ticksToTimeSpanString(asMs, resolution);
+        expect(result).toBe(expected);
+      });
+    });
+  });
+});
+
+class DateTestHelper {
+  static toMs(input: TimeArray) {
+    const [days, hours, minutes, seconds] = input;
+    const daysMs = Math.floor(days * 86400000);
+    const hoursMs = Math.floor(hours * 3600000);
+    const minutesMs = Math.floor(minutes * 60000);
+    const secondsMs = Math.floor(seconds * 1000);
+
+    const sumMs = daysMs + hoursMs + minutesMs + secondsMs;
+    return sumMs;
+  }
+}


### PR DESCRIPTION
_(quick introduction: Hello curious reader, I'll be joining Curvelabs officially on the 1st Jan 2022 as a Frontend Engineer)_

## What was done
a. fix #688 by adding `largest` to `projectTokenInfo.html` e6f6cd96558d1534b0f1732f766e643e102962c0
b. change how `largest` behaves a71d3df0885930202dae20b0209f01348d73de4e

## Testing
http://localhost:3330/lbp/0x7c10deE4389feE638e2E84dC1671B25d7DF2935f (testing url)
1. Navigate to `/launches` route
2. select a type `lpb`

### For `a.`

#### Before
Only showed hours
![image](https://user-images.githubusercontent.com/30693990/146970305-50ddb60d-b2f1-49a8-89b7-93d7c65d3538.png)

#### After
Show hours and minutes (aka. the largest 2 
![image](https://user-images.githubusercontent.com/30693990/146969384-dbd22107-7179-4efc-b3fc-138a85b76681.png)

### For `b.`
#### Before
![image](https://user-images.githubusercontent.com/30693990/146971156-77097191-246e-4ad9-8689-6e40bc48fe6c.png)

#### After
Only 2 largest
![image](https://user-images.githubusercontent.com/30693990/146970864-63275fed-7b07-4149-9157-2b05e5a61880.png)

/launches
![image](https://user-images.githubusercontent.com/30693990/146974361-e99460c8-646c-40d5-8b25-6e5460b7c21c.png)

##### Responsiveness check

https://user-images.githubusercontent.com/30693990/146975648-9c63770f-f427-492e-bf04-8153e9447a25.mp4


