### PR TITLE
Unify builds for vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
   "homepage": "./",
   "license": "MIT",
   "scripts": {
-    "build": "cross-env DOTENV_CONFIG_PATH=.env.production NETWORK=mainnet webpack --env.production --extractCss",
-    "build-vercel-dev": "cross-env DOTENV_CONFIG_PATH=.env.development webpack --env.development --extractCss",
-    "build-vercel-prod": "cross-env DOTENV_CONFIG_PATH=.env.production webpack --env.production --extractCss",
+    "build": "cross-env DOTENV_CONFIG_PATH=.env webpack",
     "build-arbitrum": "cross-env DOTENV_CONFIG_PATH=.env.production NETWORK=arbitrum webpack --env.production --extractCss",
     "build-kovan": "cross-env DOTENV_CONFIG_PATH=.env.production NETWORK=kovan webpack --env.production  --extractCss",
     "build-rinkeby": "cross-env DOTENV_CONFIG_PATH=.env.production NETWORK=rinkeby webpack --env.production  --extractCss",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,266 +41,276 @@ const sassRules = [
   }
 ];
 
-module.exports = ({ production } = {}, { extractCss, analyze, tests, hmr, port, host } = {}) => ({
-  resolve: {
-    extensions: ['.ts', '.js'],
-    modules: [srcDir, 'node_modules'],
+module.exports = ( { production } = {}, { extractCss, analyze, tests, hmr, port, host } = {} ) => {
+  const productionFlagFromEnvFile = process.env.PRODUCTION === "true"
+  production = productionFlagFromEnvFile ? productionFlagFromEnvFile : production
 
-    alias: {
-      // https://github.com/aurelia/dialog/issues/387
-      // Uncomment next line if you had trouble to run aurelia-dialog on IE11
-      // 'aurelia-dialog': path.resolve(__dirname, 'node_modules/aurelia-dialog/dist/umd/aurelia-dialog.js'),
+  const extractCssFlagFromEnvFile = process.env.EXTRACT_CSS === "true"
+  extractCss = extractCssFlagFromEnvFile ? extractCssFlagFromEnvFile : extractCss
 
-      // https://github.com/aurelia/binding/issues/702
-      // Enforce single aurelia-binding, to avoid v1/v2 duplication due to
-      // out-of-date dependencies on 3rd party aurelia plugins
-      'aurelia-binding': path.resolve(__dirname, 'node_modules/aurelia-binding'),
-      "styles": path.resolve(__dirname, "src/styles"),
-    }
-  },
-  entry: {
-    app: [
-      // Uncomment next line if you need to support IE11
-      // 'promise-polyfill/src/polyfill',
-      'aurelia-bootstrapper'
-    ]
-  },
-  node: {
-    fs: "empty"
-  },
-  mode: production ? 'production' : 'development',
-  output: {
-    path: outDir,
-    publicPath: baseUrl,
-    filename: production ? '[name].[chunkhash].bundle.js' : '[name].[hash].bundle.js',
-    sourceMapFilename: production ? '[name].[chunkhash].bundle.map' : '[name].[hash].bundle.map',
-    chunkFilename: production ? '[name].[chunkhash].chunk.js' : '[name].[hash].chunk.js'
-  },
-  optimization: {
-    runtimeChunk: true,  // separates the runtime chunk, required for long term cacheability
-    // moduleIds is the replacement for HashedModuleIdsPlugin and NamedModulesPlugin deprecated in https://github.com/webpack/webpack/releases/tag/v4.16.0
-    // changes module id's to use hashes be based on the relative path of the module, required for long term cacheability
-    moduleIds: 'hashed',
-    // Use splitChunks to breakdown the App/Aurelia bundle down into smaller chunks
-    // https://webpack.js.org/plugins/split-chunks-plugin/
-    splitChunks: {
-      hidePathInfo: true, // prevents the path from being used in the filename when using maxSize
-      chunks: "initial",
-      // sizes are compared against source before minification
+  console.log( `Running ${ production ? "PRODUCTION" : "DEVELOPMENT" } build. ${ extractCss ? "" : "Not " }extracting CSS.` )
 
-      // This is the HTTP/1.1 optimized maxSize.
-      maxSize: 200000, // splits chunks if bigger than 200k, adjust as required (maxSize added in webpack v4.15)
-      /* This is the HTTP/2 optimized options.
-      maxInitialRequests: Infinity, // Default is 3, make this unlimited if using HTTP/2
-      maxAsyncRequests: Infinity, // Default is 5, make this unlimited if using HTTP/2
-      minSize: 10000, // chunk is only created if it would be bigger than minSize, adjust as required
-      maxSize: 40000, // splits chunks if bigger than 40k, adjust as required (maxSize added in webpack v4.15)
-      */
+  return {
+    resolve: {
+      extensions: [ '.ts', '.js' ],
+      modules: [ srcDir, 'node_modules' ],
 
-      cacheGroups: {
-        default: false, // Disable the built-in groups default & vendors (vendors is redefined below)
-        // You can insert additional cacheGroup entries here if you want to split out specific modules
-        // This is required in order to split out vendor css from the app css when using --extractCss
-        // For example to separate font-awesome and bootstrap:
-        // fontawesome: { // separates font-awesome css from the app css (font-awesome is only css/fonts)
-        //   name: 'vendor.font-awesome',
-        //   test:  /[\\/]node_modules[\\/]font-awesome[\\/]/,
-        //   priority: 100,
-        //   enforce: true
-        // },
-        // bootstrap: { // separates bootstrap js from vendors and also bootstrap css from app css
-        //   name: 'vendor.bootstrap',
-        //   test:  /[\\/]node_modules[\\/]bootstrap[\\/]/,
-        //   priority: 90,
-        //   enforce: true
-        // },
+      alias: {
+        // https://github.com/aurelia/dialog/issues/387
+        // Uncomment next line if you had trouble to run aurelia-dialog on IE11
+        // 'aurelia-dialog': path.resolve(__dirname, 'node_modules/aurelia-dialog/dist/umd/aurelia-dialog.js'),
 
-        // This is the HTTP/1.1 optimized cacheGroup configuration.
-        vendors: { // picks up everything from node_modules as long as the sum of node modules is larger than minSize
-          test: /[\\/]node_modules[\\/]/,
-          name: 'vendors',
-          priority: 19,
-          enforce: true, // causes maxInitialRequests to be ignored, minSize still respected if specified in cacheGroup
-          minSize: 30000 // use the default minSize
-        },
-        vendorsAsync: { // vendors async chunk, remaining asynchronously used node modules as single chunk file
-          test: /[\\/]node_modules[\\/]/,
-          name: 'vendors.async',
-          chunks: 'async',
-          priority: 9,
-          reuseExistingChunk: true,
-          minSize: 10000  // use smaller minSize to avoid too much potential bundle bloat due to module duplication.
-        },
-        commonsAsync: { // commons async chunk, remaining asynchronously used modules as single chunk file
-          name: 'commons.async',
-          minChunks: 2, // Minimum number of chunks that must share a module before splitting
-          chunks: 'async',
-          priority: 0,
-          reuseExistingChunk: true,
-          minSize: 10000  // use smaller minSize to avoid too much potential bundle bloat due to module duplication.
-        }
-
-        /* This is the HTTP/2 optimized cacheGroup configuration.
-        // generic 'initial/sync' vendor node module splits: separates out larger modules
-        vendorSplit: { // each node module as separate chunk file if module is bigger than minSize
-          test: /[\\/]node_modules[\\/]/,
-          name(module) {
-            // Extract the name of the package from the path segment after node_modules
-            const packageName = module.context.match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/)[1];
-            return `vendor.${packageName.replace('@', '')}`;
-          },
-          priority: 20
-        },
-        vendors: { // picks up everything else being used from node_modules that is less than minSize
-          test: /[\\/]node_modules[\\/]/,
-          name: "vendors",
-          priority: 19,
-          enforce: true // create chunk regardless of the size of the chunk
-        },
-        // generic 'async' vendor node module splits: separates out larger modules
-        vendorAsyncSplit: { // vendor async chunks, create each asynchronously used node module as separate chunk file if module is bigger than minSize
-          test: /[\\/]node_modules[\\/]/,
-          name(module) {
-            // Extract the name of the package from the path segment after node_modules
-            const packageName = module.context.match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/)[1];
-            return `vendor.async.${packageName.replace('@', '')}`;
-          },
-          chunks: 'async',
-          priority: 10,
-          reuseExistingChunk: true,
-          minSize: 5000 // only create if 5k or larger
-        },
-        vendorsAsync: { // vendors async chunk, remaining asynchronously used node modules as single chunk file
-          test: /[\\/]node_modules[\\/]/,
-          name: 'vendors.async',
-          chunks: 'async',
-          priority: 9,
-          reuseExistingChunk: true,
-          enforce: true // create chunk regardless of the size of the chunk
-        },
-        // generic 'async' common module splits: separates out larger modules
-        commonAsync: { // common async chunks, each asynchronously used module a separate chunk file if module is bigger than minSize
-          name(module) {
-            // Extract the name of the module from last path component. 'src/modulename/' results in 'modulename'
-            const moduleName = module.context.match(/[^\\/]+(?=\/$|$)/)[0];
-            return `common.async.${moduleName.replace('@', '')}`;
-          },
-          minChunks: 2, // Minimum number of chunks that must share a module before splitting
-          chunks: 'async',
-          priority: 1,
-          reuseExistingChunk: true,
-          minSize: 5000 // only create if 5k or larger
-        },
-        commonsAsync: { // commons async chunk, remaining asynchronously used modules as single chunk file
-          name: 'commons.async',
-          minChunks: 2, // Minimum number of chunks that must share a module before splitting
-          chunks: 'async',
-          priority: 0,
-          reuseExistingChunk: true,
-          enforce: true // create chunk regardless of the size of the chunk
-        }
-        */
+        // https://github.com/aurelia/binding/issues/702
+        // Enforce single aurelia-binding, to avoid v1/v2 duplication due to
+        // out-of-date dependencies on 3rd party aurelia plugins
+        'aurelia-binding': path.resolve( __dirname, 'node_modules/aurelia-binding' ),
+        "styles": path.resolve( __dirname, "src/styles" ),
       }
-    }
-  },
-  performance: { hints: false },
-  devServer: {
-    contentBase: outDir,
-    // serve index.html for all 404 (required for push-state)
-    historyApiFallback: true,
-    open: project.platform.open,
-    hot: hmr || project.platform.hmr,
-    port: port || project.platform.port,
-    host: host
-  },
-  devtool: production ? 'nosources-source-map' : 'cheap-module-eval-source-map',
-  module: {
-    rules: [
-      {
-        test: /\.md$/i,
-        use: 'raw-loader',
-      },
-      // CSS required in JS/TS files should use the style-loader that auto-injects it into the website
-      // only when the issuer is a .js/.ts file, so the loaders are not applied inside html templates
-      {
-        test: /\.css$/i,
-        issuer: [{ not: [{ test: /\.html$/i }] }],
-        use: extractCss ? [{
-          loader: MiniCssExtractPlugin.loader
-        }, ...cssRules
-        ] : ['style-loader', ...cssRules]
-      },
-      {
-        test: /\.css$/i,
-        issuer: [{ test: /\.html$/i }],
-        // CSS required in templates cannot be extracted safely
-        // because Aurelia would try to require it again in runtime
-        use: cssRules
-      },
-      {
-        test: /\.scss$/,
-        use: extractCss ? [{
-          loader: MiniCssExtractPlugin.loader
-        }, ...cssRules, ...sassRules
-        ]: ['style-loader', ...cssRules, ...sassRules],
-        issuer: /\.[tj]s$/i
-      },
-      {
-        test: /\.scss$/,
-        use: [...cssRules, ...sassRules],
-        issuer: /\.html?$/i
-      },
-      { test: /\.html$/i, loader: 'html-loader' },
-      { test: /\.ts$/, loader: "ts-loader" },
-      // embed small images and fonts as Data Urls and larger ones as files:
-      { test: /\.(png|gif|jpg|cur)$/i, loader: 'url-loader', options: { limit: 8192 } },
-      { test: /\.woff2(\?v=[0-9]\.[0-9]\.[0-9])?$/i, loader: 'url-loader', options: { limit: 10000, mimetype: 'application/font-woff2' } },
-      { test: /\.woff(\?v=[0-9]\.[0-9]\.[0-9])?$/i, loader: 'url-loader', options: { limit: 10000, mimetype: 'application/font-woff' } },
-      // load these fonts normally, as files:
-      { test: /\.(ttf|eot|svg|otf)(\?v=[0-9]\.[0-9]\.[0-9])?$/i, loader: 'file-loader' },
-      {
-        test: /environment\.json$/i, use: [
-          { loader: "app-settings-loader", options: { env: production ? 'production' : 'development' } },
-        ]
-      },
-      ...when(tests, {
-        test: /\.[jt]s$/i, loader: 'istanbul-instrumenter-loader',
-        include: srcDir, exclude: [/\.(spec|test)\.[jt]s$/i],
-        enforce: 'post', options: { esModules: true },
-      })
-    ]
-  },
-  plugins: [
-    ...when(!tests, new DuplicatePackageCheckerPlugin()),
-    new AureliaPlugin(),
-    new ModuleDependenciesPlugin({
-      'aurelia-testing': ['./compile-spy', './view-spy']
-    }),
-    new HtmlWebpackPlugin({
-      template: 'index.ejs',
-      metadata: {
-        // available in index.ejs //
-        baseUrl
-      }
-    }),
-    // ref: https://webpack.js.org/plugins/mini-css-extract-plugin/
-    ...when(extractCss, new MiniCssExtractPlugin({ // updated to match the naming conventions for the js files
-      filename: production ? '[name].[contenthash].bundle.css' : '[name].[hash].bundle.css',
-      chunkFilename: production ? '[name].[contenthash].chunk.css' : '[name].[hash].chunk.css'
-    })),
-    ...when(!tests, new CopyWebpackPlugin({
-      patterns: [
-        { from: 'static', to: outDir, globOptions: { ignore: ['.*'] } }
+    },
+    entry: {
+      app: [
+        // Uncomment next line if you need to support IE11
+        // 'promise-polyfill/src/polyfill',
+        'aurelia-bootstrapper'
       ]
-    })), // ignore dot (hidden) files
-    ...when(analyze, new BundleAnalyzerPlugin()),
-    /**
-     * Note that the usage of following plugin cleans the webpack output directory before build.
-     * In case you want to generate any file in the output path as a part of pre-build step, this plugin will likely
-     * remove those before the webpack build. In that case consider disabling the plugin, and instead use something like
-     * `del` (https://www.npmjs.com/package/del), or `rimraf` (https://www.npmjs.com/package/rimraf).
-     */
-    new CleanWebpackPlugin(),
-    new EnvironmentPlugin(process.env)
-  ]
-});
+    },
+    node: {
+      fs: "empty"
+    },
+    mode: production ? 'production' : 'development',
+    output: {
+      path: outDir,
+      publicPath: baseUrl,
+      filename: production ? '[name].[chunkhash].bundle.js' : '[name].[hash].bundle.js',
+      sourceMapFilename: production ? '[name].[chunkhash].bundle.map' : '[name].[hash].bundle.map',
+      chunkFilename: production ? '[name].[chunkhash].chunk.js' : '[name].[hash].chunk.js'
+    },
+    optimization: {
+      runtimeChunk: true,  // separates the runtime chunk, required for long term cacheability
+      // moduleIds is the replacement for HashedModuleIdsPlugin and NamedModulesPlugin deprecated in https://github.com/webpack/webpack/releases/tag/v4.16.0
+      // changes module id's to use hashes be based on the relative path of the module, required for long term cacheability
+      moduleIds: 'hashed',
+      // Use splitChunks to breakdown the App/Aurelia bundle down into smaller chunks
+      // https://webpack.js.org/plugins/split-chunks-plugin/
+      splitChunks: {
+        hidePathInfo: true, // prevents the path from being used in the filename when using maxSize
+        chunks: "initial",
+        // sizes are compared against source before minification
+
+        // This is the HTTP/1.1 optimized maxSize.
+        maxSize: 200000, // splits chunks if bigger than 200k, adjust as required (maxSize added in webpack v4.15)
+        /* This is the HTTP/2 optimized options.
+        maxInitialRequests: Infinity, // Default is 3, make this unlimited if using HTTP/2
+        maxAsyncRequests: Infinity, // Default is 5, make this unlimited if using HTTP/2
+        minSize: 10000, // chunk is only created if it would be bigger than minSize, adjust as required
+        maxSize: 40000, // splits chunks if bigger than 40k, adjust as required (maxSize added in webpack v4.15)
+        */
+
+        cacheGroups: {
+          default: false, // Disable the built-in groups default & vendors (vendors is redefined below)
+          // You can insert additional cacheGroup entries here if you want to split out specific modules
+          // This is required in order to split out vendor css from the app css when using --extractCss
+          // For example to separate font-awesome and bootstrap:
+          // fontawesome: { // separates font-awesome css from the app css (font-awesome is only css/fonts)
+          //   name: 'vendor.font-awesome',
+          //   test:  /[\\/]node_modules[\\/]font-awesome[\\/]/,
+          //   priority: 100,
+          //   enforce: true
+          // },
+          // bootstrap: { // separates bootstrap js from vendors and also bootstrap css from app css
+          //   name: 'vendor.bootstrap',
+          //   test:  /[\\/]node_modules[\\/]bootstrap[\\/]/,
+          //   priority: 90,
+          //   enforce: true
+          // },
+
+          // This is the HTTP/1.1 optimized cacheGroup configuration.
+          vendors: { // picks up everything from node_modules as long as the sum of node modules is larger than minSize
+            test: /[\\/]node_modules[\\/]/,
+            name: 'vendors',
+            priority: 19,
+            enforce: true, // causes maxInitialRequests to be ignored, minSize still respected if specified in cacheGroup
+            minSize: 30000 // use the default minSize
+          },
+          vendorsAsync: { // vendors async chunk, remaining asynchronously used node modules as single chunk file
+            test: /[\\/]node_modules[\\/]/,
+            name: 'vendors.async',
+            chunks: 'async',
+            priority: 9,
+            reuseExistingChunk: true,
+            minSize: 10000  // use smaller minSize to avoid too much potential bundle bloat due to module duplication.
+          },
+          commonsAsync: { // commons async chunk, remaining asynchronously used modules as single chunk file
+            name: 'commons.async',
+            minChunks: 2, // Minimum number of chunks that must share a module before splitting
+            chunks: 'async',
+            priority: 0,
+            reuseExistingChunk: true,
+            minSize: 10000  // use smaller minSize to avoid too much potential bundle bloat due to module duplication.
+          }
+
+          /* This is the HTTP/2 optimized cacheGroup configuration.
+          // generic 'initial/sync' vendor node module splits: separates out larger modules
+          vendorSplit: { // each node module as separate chunk file if module is bigger than minSize
+            test: /[\\/]node_modules[\\/]/,
+            name(module) {
+              // Extract the name of the package from the path segment after node_modules
+              const packageName = module.context.match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/)[1];
+              return `vendor.${packageName.replace('@', '')}`;
+            },
+            priority: 20
+          },
+          vendors: { // picks up everything else being used from node_modules that is less than minSize
+            test: /[\\/]node_modules[\\/]/,
+            name: "vendors",
+            priority: 19,
+            enforce: true // create chunk regardless of the size of the chunk
+          },
+          // generic 'async' vendor node module splits: separates out larger modules
+          vendorAsyncSplit: { // vendor async chunks, create each asynchronously used node module as separate chunk file if module is bigger than minSize
+            test: /[\\/]node_modules[\\/]/,
+            name(module) {
+              // Extract the name of the package from the path segment after node_modules
+              const packageName = module.context.match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/)[1];
+              return `vendor.async.${packageName.replace('@', '')}`;
+            },
+            chunks: 'async',
+            priority: 10,
+            reuseExistingChunk: true,
+            minSize: 5000 // only create if 5k or larger
+          },
+          vendorsAsync: { // vendors async chunk, remaining asynchronously used node modules as single chunk file
+            test: /[\\/]node_modules[\\/]/,
+            name: 'vendors.async',
+            chunks: 'async',
+            priority: 9,
+            reuseExistingChunk: true,
+            enforce: true // create chunk regardless of the size of the chunk
+          },
+          // generic 'async' common module splits: separates out larger modules
+          commonAsync: { // common async chunks, each asynchronously used module a separate chunk file if module is bigger than minSize
+            name(module) {
+              // Extract the name of the module from last path component. 'src/modulename/' results in 'modulename'
+              const moduleName = module.context.match(/[^\\/]+(?=\/$|$)/)[0];
+              return `common.async.${moduleName.replace('@', '')}`;
+            },
+            minChunks: 2, // Minimum number of chunks that must share a module before splitting
+            chunks: 'async',
+            priority: 1,
+            reuseExistingChunk: true,
+            minSize: 5000 // only create if 5k or larger
+          },
+          commonsAsync: { // commons async chunk, remaining asynchronously used modules as single chunk file
+            name: 'commons.async',
+            minChunks: 2, // Minimum number of chunks that must share a module before splitting
+            chunks: 'async',
+            priority: 0,
+            reuseExistingChunk: true,
+            enforce: true // create chunk regardless of the size of the chunk
+          }
+          */
+        }
+      }
+    },
+    performance: { hints: false },
+    devServer: {
+      contentBase: outDir,
+      // serve index.html for all 404 (required for push-state)
+      historyApiFallback: true,
+      open: project.platform.open,
+      hot: hmr || project.platform.hmr,
+      port: port || project.platform.port,
+      host: host
+    },
+    devtool: production ? 'nosources-source-map' : 'cheap-module-eval-source-map',
+    module: {
+      rules: [
+        {
+          test: /\.md$/i,
+          use: 'raw-loader',
+        },
+        // CSS required in JS/TS files should use the style-loader that auto-injects it into the website
+        // only when the issuer is a .js/.ts file, so the loaders are not applied inside html templates
+        {
+          test: /\.css$/i,
+          issuer: [ { not: [ { test: /\.html$/i } ] } ],
+          use: extractCss ? [ {
+            loader: MiniCssExtractPlugin.loader
+          }, ...cssRules
+          ] : [ 'style-loader', ...cssRules ]
+        },
+        {
+          test: /\.css$/i,
+          issuer: [ { test: /\.html$/i } ],
+          // CSS required in templates cannot be extracted safely
+          // because Aurelia would try to require it again in runtime
+          use: cssRules
+        },
+        {
+          test: /\.scss$/,
+          use: extractCss ? [ {
+            loader: MiniCssExtractPlugin.loader
+          }, ...cssRules, ...sassRules
+          ] : [ 'style-loader', ...cssRules, ...sassRules ],
+          issuer: /\.[tj]s$/i
+        },
+        {
+          test: /\.scss$/,
+          use: [ ...cssRules, ...sassRules ],
+          issuer: /\.html?$/i
+        },
+        { test: /\.html$/i, loader: 'html-loader' },
+        { test: /\.ts$/, loader: "ts-loader" },
+        // embed small images and fonts as Data Urls and larger ones as files:
+        { test: /\.(png|gif|jpg|cur)$/i, loader: 'url-loader', options: { limit: 8192 } },
+        { test: /\.woff2(\?v=[0-9]\.[0-9]\.[0-9])?$/i, loader: 'url-loader', options: { limit: 10000, mimetype: 'application/font-woff2' } },
+        { test: /\.woff(\?v=[0-9]\.[0-9]\.[0-9])?$/i, loader: 'url-loader', options: { limit: 10000, mimetype: 'application/font-woff' } },
+        // load these fonts normally, as files:
+        { test: /\.(ttf|eot|svg|otf)(\?v=[0-9]\.[0-9]\.[0-9])?$/i, loader: 'file-loader' },
+        {
+          test: /environment\.json$/i, use: [
+            { loader: "app-settings-loader", options: { env: production ? 'production' : 'development' } },
+          ]
+        },
+        ...when( tests, {
+          test: /\.[jt]s$/i, loader: 'istanbul-instrumenter-loader',
+          include: srcDir, exclude: [ /\.(spec|test)\.[jt]s$/i ],
+          enforce: 'post', options: { esModules: true },
+        } )
+      ]
+    },
+    plugins: [
+      ...when( !tests, new DuplicatePackageCheckerPlugin() ),
+      new AureliaPlugin(),
+      new ModuleDependenciesPlugin( {
+        'aurelia-testing': [ './compile-spy', './view-spy' ]
+      } ),
+      new HtmlWebpackPlugin( {
+        template: 'index.ejs',
+        metadata: {
+          // available in index.ejs //
+          baseUrl
+        }
+      } ),
+      // ref: https://webpack.js.org/plugins/mini-css-extract-plugin/
+      ...when( extractCss, new MiniCssExtractPlugin( { // updated to match the naming conventions for the js files
+        filename: production ? '[name].[contenthash].bundle.css' : '[name].[hash].bundle.css',
+        chunkFilename: production ? '[name].[contenthash].chunk.css' : '[name].[hash].chunk.css'
+      } ) ),
+      ...when( !tests, new CopyWebpackPlugin( {
+        patterns: [
+          { from: 'static', to: outDir, globOptions: { ignore: [ '.*' ] } }
+        ]
+      } ) ), // ignore dot (hidden) files
+      ...when( analyze, new BundleAnalyzerPlugin() ),
+      /**
+       * Note that the usage of following plugin cleans the webpack output directory before build.
+       * In case you want to generate any file in the output path as a part of pre-build step, this plugin will likely
+       * remove those before the webpack build. In that case consider disabling the plugin, and instead use something like
+       * `del` (https://www.npmjs.com/package/del), or `rimraf` (https://www.npmjs.com/package/rimraf).
+       */
+      new CleanWebpackPlugin(),
+      new EnvironmentPlugin( process.env )
+    ]
+  }
+}


### PR DESCRIPTION
## What has been done
* Cleaned unnecessary build scripts
* Created a simple build script to run on vercel, and is defined by environment variables.
  * `PRODUCTION=true` -> builds production env
  * `PRODUCTION=false` -> builds development env
  * `EXTRACT_CSS=true` -> extracts css
* Added WebPack flags to indicate if `production` and `extractCss` are coming from the `.env` file or from a script parameter.

**NOTE:**
For Vercel to deploy correctly these environment variables are needed:
PRODUCTION=true|false
NETWORK=mainnet|rinkeby|...
EXTRACT_CSS=true|false
