### PR TITLE
Restrict node version to 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "engines": {
-    "node": ">=14.11.0"
+    "node": ">=14.11.0 <15"
   },
   "browser": {
     "http": false


### PR DESCRIPTION
This PR restricts the `Node` version to 14 and above but below 15.

It should fix an issue with Vercels build fails since some dependencies (node-sass) require a `node` version lower than 15.