### PR TITLE
785 - Set correct explorer url for each network

### DIFF
--- a/src/services/EthereumService.ts
+++ b/src/services/EthereumService.ts
@@ -545,17 +545,22 @@ export class EthereumService {
   }
 
   public getEtherscanLink(addressOrHash: Address | Hash, tx = false): string {
-    let targetedNetwork = EthereumService.targetedNetwork as string;
-    if (targetedNetwork === Networks.Arbitrum) {
-      return `https://arbiscan.io/${tx ? "tx" : "address"}/${addressOrHash}`;
+    const params = `${tx ? "tx" : "address"}/${addressOrHash}`;
+    switch (EthereumService.targetedNetwork) {
+      case Networks.Arbitrum:
+        return `https://arbiscan.io/${params}`;
+      case Networks.Alfajores:
+        return `https://alfajores-blockscout.celo-testnet.org/${params}`;
+      case Networks.Celo:
+        return `https://explorer.celo.org/${params}`;
+      case Networks.Rinkeby: // set for deprecation
+        return `https://rinkeby.etherscan.io/${params}`;
+      case Networks.Kovan: // deprecated
+        return `https://kovan.etherscan.io/${params}`;
+      case Networks.Mainnet:
+      default:
+        return `http://etherscan.io/${params}`;
     }
-    else if (targetedNetwork === Networks.Mainnet) {
-      targetedNetwork = "";
-    } else {
-      targetedNetwork = targetedNetwork + ".";
-    }
-
-    return `http://${targetedNetwork}etherscan.io/${tx ? "tx" : "address"}/${addressOrHash}`;
   }
 }
 


### PR DESCRIPTION
# What has been done
Fixed the `getEtherscanLink` function to return the correct explorer URL for each network.

Arbitrum: [https://arbiscan.io](https://arbiscan.io)
Alfajores: [https://alfajores-blockscout.celo-testnet.org](https://alfajores-blockscout.celo-testnet.org)
Celo: [https://explorer.celo.org](https://explorer.celo.org)
Rinkeby (note: set for deprecation): [https://rinkeby.etherscan.io](https://rinkeby.etherscan.io)
Kovan (note: deprecated): [https://kovan.etherscan.io](https://kovan.etherscan.io)
Mainnet: [https://etherscan.io](http://etherscan.io)
