### PR TITLE
Updates to celo safe and subgraph

### DIFF
--- a/src/contracts/celo.json
+++ b/src/contracts/celo.json
@@ -2606,7 +2606,7 @@
       ]
     },
     "Safe": {
-      "address": "0x79204a1E9a49D4C132931AdCB9F39dA90179ba1c",
+      "address": "0x0276a552F424949C934bC74bB623886AAc9Ed807",
       "abi": [
         {
           "inputs": [],
@@ -4639,7 +4639,7 @@
       ]
     },
     "SignerV2": {
-      "address": "0x86Be53D39fB8406a7192d3086ED644c5e5187cf1",
+      "address": "0x985e5d7D6630b5262069479D8DBBE29A351103B7",
       "abi": [
         {
           "inputs": [

--- a/src/newLaunch/baseStage.ts
+++ b/src/newLaunch/baseStage.ts
@@ -59,21 +59,26 @@ export abstract class BaseStage<IConfig> {
     const safeAddress = ContractsService.getContractAddress(ContractNames.SAFE);
 
     let prefix: string;
+    let url: string;
 
     switch (EthereumService.targetedNetwork) {
       case Networks.Mainnet:
         prefix = "eth:";
+        url = "gnosis-safe.io/app/";
         break;
       case Networks.Rinkeby:
         prefix = "rin:";
+        url = "gnosis-safe.io/app/";
         break;
       case Networks.Arbitrum:
         prefix = "arb1:";
+        url = "gnosis-safe.io/app/";
+        break;
+      case Networks.Celo:
+        prefix = "";
+        url = "safe.celo.org/#/safes/";
         break;
       /* TODO - Add when ready */
-      // case Networks.Celo:
-      //   prefix = "celo:";
-      //   break;
       // case Networks.Alfajores:
       //   prefix = "alfa:";
       //   break;
@@ -83,7 +88,7 @@ export abstract class BaseStage<IConfig> {
     }
 
     this.multiSigWalletUri =
-      `https://gnosis-safe.io/app/${prefix}${safeAddress}/transactions`;
+      `https://${url}${prefix}${safeAddress}/transactions`;
   }
 
   activate(_params: unknown, routeConfig: RouteConfig): void {

--- a/src/services/BalancerService.ts
+++ b/src/services/BalancerService.ts
@@ -10,7 +10,7 @@ import { BigNumber, BigNumberish } from "ethers";
 import { ITokenInfo } from "services/TokenTypes";
 import { TransactionResponse } from "@ethersproject/providers";
 
-const SUBGRAPH_URLS = {
+export const SUBGRAPH_URLS = {
   [Networks.Mainnet]:
     "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2",
   [Networks.Kovan]:
@@ -20,7 +20,7 @@ const SUBGRAPH_URLS = {
   [Networks.Arbitrum]:
     "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-arbitrum-v2",
   [Networks.Celo]: // TODO - Add correct Balancer-v2 subgraph (Symmetric?)
-    "https://api.thegraph.com/subgraphs/name/anudit/celo-subgraph",
+    "https://api.thegraph.com/subgraphs/name/centfinance/symmetric-v2-celo",
   [Networks.Alfajores]: // TODO - Add correct Balancer-v2 subgraph (Symmetric?)
     "https://api.thegraph.com/subgraphs/name/anudit/celo-subgraph",
 };

--- a/src/services/ProjectTokenHistoricalPriceService.ts
+++ b/src/services/ProjectTokenHistoricalPriceService.ts
@@ -1,3 +1,4 @@
+import { SUBGRAPH_URLS } from 'services/BalancerService';
 import { fromWei } from "./EthereumService";
 import { EthereumService, Networks } from "services/EthereumService";
 
@@ -36,7 +37,7 @@ export class ProjectTokenHistoricalPriceService {
   ) {}
 
   private getBalancerSubgraphUrl(): string {
-    return `https://api.thegraph.com/subgraphs/name/balancer-labs/balancer${(EthereumService.targetedNetwork !== Networks.Mainnet) ? ("-" + EthereumService.targetedNetwork + "-v2") : "-v2"}`;
+    return SUBGRAPH_URLS[EthereumService.targetedNetwork];
   }
 
   private getCoingeckoUrl(fundingTokenId: string, startTime: number, endTime: number): string {


### PR DESCRIPTION
### What was done?

- Updated Celo contract to latest (from this [commit](https://github.com/PrimeDAO/contracts-v2/commit/dcd9f81e990438dedb3cbd78622b3dc9e072357c)). 
  Implements new Safe and Signer addresses.
- Updated Celo Safe URL
  Support network nuances to the safe URL.
- Updated Celo Subgraph URL
  Though LBP-related, it intersects with `adding Celo network` for v1.
- Reused `BalancerService` subgraph URL in the `ProjectTokenHistoricalPriceService`
  Small refactor to reduce future risks
