### PR TITLE
sc 760 - wizard seed details: add missing fields

### DIFF
--- a/src/newLaunch/baseStage.scss
+++ b/src/newLaunch/baseStage.scss
@@ -338,6 +338,11 @@
     align-self: center;
   }
 
+  .toggle-description {
+    line-height: 24px;
+    margin: 2px 0;
+  }
+
   .importantText {
     font-weight: 800;
   }

--- a/src/newLaunch/baseStage.scss
+++ b/src/newLaunch/baseStage.scss
@@ -926,6 +926,13 @@
       cursor: pointer;
       &.isInactive {
         background: $Secondary05;
+        cursor: default;
+
+        .checkbox {
+          label {
+            cursor: default;
+          }
+        }
       }
       i.yes {
         position: absolute;

--- a/src/newLaunch/baseStage.scss
+++ b/src/newLaunch/baseStage.scss
@@ -130,7 +130,7 @@
 .make-admin-button {
   @include boldButton;
   margin-top: 40px;
-  margin-bottom: 80px;
+  margin-bottom: 16px;
 }
 
 .end-stage-subtext {
@@ -769,7 +769,8 @@
           }
         }
       }
-      .vestingPeriod {
+      .vestingPeriod,
+      .seedTipping {
         width: 176px;
         display: flex;
         flex-flow: row nowrap;
@@ -796,7 +797,8 @@
         grid-template-columns: auto auto;
       }
 
-      .vestingDates {
+      .vestingDates,
+      .seedTipping {
         width: 176px;
         display: grid;
         grid-template-columns: auto auto;
@@ -823,6 +825,18 @@
           > i {
             font-size: 22px;
           }
+        }
+      }
+
+      .seedTipping {
+        width: 104px;
+        margin-bottom: 80px;
+
+        input {
+          width: 57px;
+        }
+        > div {
+          width: 47px;
         }
       }
     }

--- a/src/newLaunch/permissoned.html
+++ b/src/newLaunch/permissoned.html
@@ -1,0 +1,23 @@
+<template bindable="checked, toggle, disabled">
+  <div class="infoInput">
+    <div class="labeledQuestion">
+      <label for="geoBlock">Set Permission-less SEED</label>
+      <div class="questionMark">
+        <question-mark allow-html
+          text="TODO">
+        </question-mark>
+      </div>
+    </div>
+    <p class="toggle-description">Permission-less SEED is..</p>
+
+    <div class="checkboxContainer ${!checked ? 'isInactive' : ''}"
+      click.delegate="toggle()">
+      <i class="fas fa-check yes"></i>
+      <i class="fas fa-times no"></i>
+      <div class="checkbox">
+        <input id="geoBlock" type="checkbox" disabled.bind="disabled" checked.bind="checked" />
+        <label for="geoBlock" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/newLaunch/seed/config.ts
+++ b/src/newLaunch/seed/config.ts
@@ -25,6 +25,7 @@ export interface ISeedDetails extends ILaunchDetails {
   vestingPeriod: number,
   vestingCliff: number,
   whitelist: string,
+  isPermissoned: boolean,
   legalDisclaimer: string,
 }
 

--- a/src/newLaunch/seed/config.ts
+++ b/src/newLaunch/seed/config.ts
@@ -27,6 +27,7 @@ export interface ISeedDetails extends ILaunchDetails {
   whitelist: string,
   isPermissoned: boolean,
   legalDisclaimer: string,
+  seedTip: number,
 }
 
 export interface ISeedConfig extends ILaunchConfig {

--- a/src/newLaunch/seed/stages/stage4.html
+++ b/src/newLaunch/seed/stages/stage4.html
@@ -1,6 +1,7 @@
 <template>
   <require from="newLaunch/tokenLabel.html"></require>
   <require from="newLaunch/geoblocking.html"></require>
+  <require from="newLaunch/permissoned.html"></require>
 
   <div class="page animated-page stageContainer stage4 au-animate ">
     <div class="infoContainer">
@@ -150,6 +151,11 @@
               <div if.bind="!allowlistUrlIsValid && csv" class="allowListFeedback bad"><i class="fas fa-exclamation-triangle"></i> Whitelist cannot be loaded or contains no accounts</div>
             </div>
           </div>
+
+          <permissoned
+            checked.bind="launchConfig.launchDetails.isPermissoned"
+            toggle.call="togglePermissoned()">
+          </permissoned>
 
           <span class="label">Classes Set-up</span>
           <div class="classes-overview-container">

--- a/src/newLaunch/seed/stages/stage4.html
+++ b/src/newLaunch/seed/stages/stage4.html
@@ -279,6 +279,27 @@
             </template>
           </div>
         </div>
+
+        <div class="labeledQuestion">
+          <label for="vestingPeriod">Tipping</label>
+          <div class="questionMark">
+            <question-mark text="TODO"></question-mark>
+          </div>
+        </div>
+
+        <div class="infoInput maxTarget maxTargetLabel">
+          <div>
+            <div class="seedTipping">
+              <numeric-input
+                placeholder="1"
+                id="vestingPeriod"
+                not-wei
+                value.bind="launchConfig.launchDetails.seedTip">
+              </numeric-input>
+              <div>%</div>
+            </div>
+          </div>
+        </div>
       </div>
 
       <div class="footerButtons">

--- a/src/newLaunch/seed/stages/stage4.ts
+++ b/src/newLaunch/seed/stages/stage4.ts
@@ -106,6 +106,10 @@ export class Stage4 extends BaseStage<ISeedConfig> {
     this.launchConfig.launchDetails.pricePerToken = null;
   }
 
+  togglePermissoned(): void {
+    this.launchConfig.launchDetails.isPermissoned = !this.launchConfig.launchDetails.isPermissoned;
+  }
+
   toggleGeoBlocking(): void {
     this.launchConfig.launchDetails.geoBlock = !this.launchConfig.launchDetails.geoBlock;
   }
@@ -136,7 +140,7 @@ export class Stage4 extends BaseStage<ISeedConfig> {
     // Save the admin address to wizard state in order to persist it after launchConfig state is cleared in stage7
     this.wizardState.launchAdminAddress = this.launchConfig.launchDetails.adminAddress;
     // TODO: Refactor after BE enables allowlists:
-    // this.wizardState.whiteList = this.launchConfig.launchDetails.whitelist; 
+    // this.wizardState.whiteList = this.launchConfig.launchDetails.whitelist;
     this.wizardState.launchStartDate = this.launchConfig.launchDetails.startDate;
   }
 

--- a/src/newLaunch/seed/stages/stage6.html
+++ b/src/newLaunch/seed/stages/stage6.html
@@ -260,7 +260,7 @@
                   <div class="heading heading4">
                     Tipping
                   </div>
-                  1%
+                  ${launchConfig.launchDetails.seedTip || "--"}%
                 </div>
                 <div class="stageLaunchDetails">
                   <div class="heading heading4">

--- a/src/newLaunch/seed/stages/stage6.html
+++ b/src/newLaunch/seed/stages/stage6.html
@@ -1,6 +1,8 @@
 <template>
   <require from="../../stages/stageSixTokenInfo.html"></require>
   <require from="newLaunch/geoblocking.html"></require>
+  <require from="newLaunch/permissoned.html"></require>
+
   <div class="page animated-page stageContainer stage6 au-animate ">
     <div class="infoContainer">
       <div class="heading heading2 title">Seed Summary</div>
@@ -165,7 +167,7 @@
                 </div>
                 <div class="inline">
                 <div class="stageLaunchDetails">
-            
+
                     <div class="heading heading4">Tokens vested for</div>
                     <div class="tokenAmountContainer">
                       <div class="tokenAmount">
@@ -182,6 +184,14 @@
                     </div>
                   </div>
                 </div>
+                </div>
+                <div class="stageLaunchDetails">
+                  <permissoned
+                    checked.bind="launchConfig.launchDetails.isPermissoned"
+                    disabled.bind="true"
+                    toggle.call="toggle()"
+                  >
+                  </permissoned>
                 </div>
                 <div class="stageLaunchDetails">
                   <div class="heading heading4">Allowlist</div>

--- a/src/services/SeedService.ts
+++ b/src/services/SeedService.ts
@@ -242,7 +242,7 @@ export class SeedService {
       Date.parse(config.launchDetails.endDate) / 1000,
       [config.launchDetails.vestingPeriod, config.launchDetails.vestingCliff],
       config.launchDetails.isPermissoned,
-      toWei(SeedService.seedFee),
+      toWei(config.launchDetails.seedTip ?? 0.0),
       Utils.asciiToHex(metaDataHash),
     ];
     transaction.data = (await seedFactory.populateTransaction.deploySeed(...seedArguments)).data;

--- a/src/services/SeedService.ts
+++ b/src/services/SeedService.ts
@@ -241,7 +241,7 @@ export class SeedService {
       // convert from ISO string to Unix epoch seconds
       Date.parse(config.launchDetails.endDate) / 1000,
       [config.launchDetails.vestingPeriod, config.launchDetails.vestingCliff],
-      !!config.launchDetails.whitelist,
+      config.launchDetails.isPermissoned,
       toWei(SeedService.seedFee),
       Utils.asciiToHex(metaDataHash),
     ];


### PR DESCRIPTION
## What was done
Seed config
- feat(seed.config): add isPermissioned prop
- feat(seed.config): add seedTip prop

SeedService
- feat(services): update isPermissioned prop
- feat(services): update where tip is taken from

Wizard Seed Details
- feat(wizard.seedDetails): add permissionedToggle
- feat(wizard.seedDetails): add tipping

Wizard Summary
- feat(wizard.summary): add permissoned toggle
- feat(wizard.summary): take tipping from object
- styles(wizard.summary): cursor:default to toggle

## Testing

### Before
missing sections

### After
added sections, and they should be connected (stage 4 with summary page)