### PR TITLE
bug/sc-163/wizard-stepper-labels-unaligned

### DIFF
--- a/src/newLaunch/launch.scss
+++ b/src/newLaunch/launch.scss
@@ -37,7 +37,7 @@
   }
 
   .currentStageSidebar {
-    line-height: 32px;
+    line-height: 22px;
     font-size: 18px;
     font-family: Inter;
     font-weight: 300;
@@ -83,6 +83,8 @@
       font-size: 18px;
       font-weight: 400;
       font-family: Inter;
+      text-align: center;
+      padding: 10px 0;
     }
 
     .stageActive {


### PR DESCRIPTION
### What was done
Fixed `Stage Sidebar` Title in the wizard alignment to be centred.

#### Before
![image](https://user-images.githubusercontent.com/2517870/192540565-b6aee419-2602-434c-be3f-1b4c1b15a1b8.png)

#### Result
![image](https://user-images.githubusercontent.com/2517870/192540600-20d1ca9d-ccb9-4f51-ba52-ab78df44f19f.png)
