### PR TITLE
[Admin-Dashboard | sc-1007]: Admin-dashboard-classes-cancel-should-be-disabled

### DIFF
--- a/src/admin/seeds/dashboard/dashboard.html
+++ b/src/admin/seeds/dashboard/dashboard.html
@@ -158,7 +158,7 @@
                     </div>
                     <div class="deployActions" if.bind="selectedSeed.classes.length">
                       <div class="buttonContainer">
-                        <div class="stageButton cancel" click.delegate="cancel()"><span>Cancel</span></div>
+                        <div class="stageButton cancel ${isDisabled.cancel ? 'disabled':''}" click.delegate="cancel()"><span>Cancel</span></div>
                       </div>
                       <div class="buttonContainer">
                         <div class="stageButton button1 ${noAdditions || isMinting[-1] ? 'disabled' : ''}" click.delegate="deployClassesToContract()">

--- a/src/admin/seeds/dashboard/dashboard.html
+++ b/src/admin/seeds/dashboard/dashboard.html
@@ -158,7 +158,7 @@
                     </div>
                     <div class="deployActions" if.bind="selectedSeed.classes.length">
                       <div class="buttonContainer">
-                        <div class="stageButton cancel ${isDisabled.cancel ? 'disabled':''}" click.delegate="cancel()"><span>Cancel</span></div>
+                        <div class="stageButton cancel ${noAdditions || isMinting[-1] ? 'disabled':''}" click.delegate="cancel()"><span>Cancel</span></div>
                       </div>
                       <div class="buttonContainer">
                         <div class="stageButton button1 ${noAdditions || isMinting[-1] ? 'disabled' : ''}" click.delegate="deployClassesToContract()">

--- a/src/admin/seeds/dashboard/dashboard.scss
+++ b/src/admin/seeds/dashboard/dashboard.scss
@@ -137,7 +137,13 @@
             color: $Neutral02;
             cursor: not-allowed;
           }
+        }
+        .cancel {
+          &.disabled {
+            color: $Neutral02;
+            cursor: not-allowed;
           }
+        }
       }
 
       .noSeedCreatedMessage {

--- a/src/admin/seeds/dashboard/dashboard.ts
+++ b/src/admin/seeds/dashboard/dashboard.ts
@@ -30,7 +30,6 @@ export class SeedAdminDashboard {
   loading = true;
   newlyAddedClassesIndexes: number[] = [];
   isMinting: Record<number, boolean> = {};
-  isDisabled: Record<string, boolean> = {"cancel": true}
 
   @computedFrom("ethereumService.defaultAccountAddress")
   get connected(): boolean {
@@ -211,7 +210,6 @@ export class SeedAdminDashboard {
 
   @computedFrom("newlyAddedClassesIndexes.length")
   get noAdditions(): boolean {
-    this.isDisabled.cancel = !this.newlyAddedClassesIndexes.length;
     return !this.newlyAddedClassesIndexes.length;
   }
 
@@ -274,7 +272,7 @@ export class SeedAdminDashboard {
   }
 
   cancel() {
-    if (this.isDisabled.cancel) return;
+    if (this.noAdditions) return;
     // TODO: Add cancel logic.
     // Remove new add classes
     // Undo edit

--- a/src/admin/seeds/dashboard/dashboard.ts
+++ b/src/admin/seeds/dashboard/dashboard.ts
@@ -30,6 +30,7 @@ export class SeedAdminDashboard {
   loading = true;
   newlyAddedClassesIndexes: number[] = [];
   isMinting: Record<number, boolean> = {};
+  isDisabled: Record<string, boolean> = {"cancel": true}
 
   @computedFrom("ethereumService.defaultAccountAddress")
   get connected(): boolean {
@@ -210,6 +211,7 @@ export class SeedAdminDashboard {
 
   @computedFrom("newlyAddedClassesIndexes.length")
   get noAdditions(): boolean {
+    this.isDisabled.cancel = !this.newlyAddedClassesIndexes.length;
     return !this.newlyAddedClassesIndexes.length;
   }
 
@@ -272,6 +274,7 @@ export class SeedAdminDashboard {
   }
 
   cancel() {
+    if (this.isDisabled.cancel) return;
     // TODO: Add cancel logic.
     // Remove new add classes
     // Undo edit


### PR DESCRIPTION
## What was done
Disabled the `Cancel` button if no classes are added.

### No changes:
![image](https://user-images.githubusercontent.com/2517870/192833031-ab8b2695-32ab-48e9-be7c-c9327f505fe9.png)

### Class added:
![image](https://user-images.githubusercontent.com/2517870/192833093-77919aff-6438-46bd-832f-37f9900bee68.png)
