### PR TITLE
[Admin Dashboard | sc-1011]: classes-cancel-should-restore-inisial-state

### DIFF
--- a/src/admin/seeds/dashboard/dashboard.ts
+++ b/src/admin/seeds/dashboard/dashboard.ts
@@ -272,9 +272,9 @@ export class SeedAdminDashboard {
   }
 
   cancel() {
-    // TODO: Add cancel logic.
-    // Remove new add classes
-    // Undo edit
-    this.selectedSeed.classes = []; /* <- Temporary */
+    if (this.noAdditions) return;
+    const firstNewlyAddedClass = this.newlyAddedClassesIndexes[0];
+    this.selectedSeed.classes.splice(firstNewlyAddedClass);
+    this.newlyAddedClassesIndexes = [];
   }
 }


### PR DESCRIPTION
## What was done
Fixed: Clicking the `Cancel` button, removes non-deployed classes from the list.