### PR TITLE
[Bug/sc-1017]: permission-reverse-logic-for-toggle-is-permissioned

### DIFF
--- a/src/newLaunch/seed/config.ts
+++ b/src/newLaunch/seed/config.ts
@@ -51,6 +51,8 @@ export class SeedConfig extends LaunchConfig implements ISeedConfig {
     this.launchDetails.vestingPeriod = null;
     this.launchDetails.vestingCliff = null;
     this.launchDetails.whitelist = "";
+    this.launchDetails.isPermissoned = true;
     this.launchDetails.legalDisclaimer = "";
+    this.launchDetails.seedTip = null;
   }
 }


### PR DESCRIPTION
## What was done
* Fixed `isPermissioned` to be true by default.
* Added side fix- resetting `seedTip` to null. This is not important for default load, but if going back to the form after submitting, it should be cleared...