### PR TITLE
[bug/sc-1022]: summary-start-date-date-format-29-jan-2022

### DIFF
--- a/src/newLaunch/seed/stages/stage6.html
+++ b/src/newLaunch/seed/stages/stage6.html
@@ -210,7 +210,7 @@
                       Start Date (GMT)
                     </div>
                     <div>
-                      ${launchConfig.launchDetails.startDate | date:{format:"DD-MM-YYYY", utc: true}}
+                      ${launchConfig.launchDetails.startDate | date:{format:"DD-MMM-YYYY", utc: true}}
                     </div>
                   </div>
                   <div class="stageLaunchDetails">
@@ -226,7 +226,7 @@
                       End Date (GMT)
                     </div>
                     <div>
-                      ${launchConfig.launchDetails.endDate | date:{format:"DD-MM-YYYY", utc:true}}
+                      ${launchConfig.launchDetails.endDate | date:{format:"DD-MMM-YYYY", utc:true}}
                     </div>
                   </div>
                   <div class="stageLaunchDetails">


### PR DESCRIPTION
## What was done

Adjusted the date format to `DD-MMM-YYYY`.
(NOTE: I've allowed myself to apply this format to the end-time too, though it wasn't specified in the ticket)

![image](https://user-images.githubusercontent.com/2517870/195617163-25d38c17-57b9-4349-9670-01eaf029c1f7.png)

